### PR TITLE
Allow cross-site cookies so that login sessions are possible

### DIFF
--- a/server/config/environments/production.rb
+++ b/server/config/environments/production.rb
@@ -3,6 +3,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Allow cross-site cookies
+  config.action_dispatch.cookies_same_site_protection = :None
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
This is an attempt to fix the issue with cookies on the deployment. The issue seems to be the fact that, unlike when working locally with localhost, the deployed servers are on different sites (i.e., Netlify and Heroku), and cross-site cookies are not allowed by default.
Relevant article with solution: https://medium.com/@ArturoAlvarezV/use-session-cookies-to-authenticate-a-user-with-a-rails-api-backend-hosted-in-heroku-on-one-domain-f702ddf8c07