### PR TITLE
Take `company_id` as user param

### DIFF
--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -86,16 +86,31 @@ class UsersController < ApplicationController
              }, status: :bad_request
     end
 
+    if params["user"]["company_id"] != nil and params["user"]["usertype"] != "company representative"
+      return render json: {
+                      errors: ["Company ID cannot be provided to user of type  #{params[:user][:usertype]}"],
+                    }, status: :bad_request
+    end
+
+    if exact_match != nil
+      company = exact_match.company
+    else
+      company = domain_match.company
+    end
+
+    # If company found with allowlist doesn't match the company found with the provided company_id
+    if params["user"]["company_id"] and company != Company.find(params["user"]["company_id"])
+      return render json: {
+                      errors: ["Email not allowed for provided company of id #{params[:user][:company_id]}"],
+                    }, status: :bad_request
+    end
+
     @user = User.new(user_params)
     if @user.save
       login!
       resp = UserMailer.registration_confirmation(@user).deliver_now
       if params["user"]["usertype"] == "company representative"
-        if exact_match != nil
-          exact_match.company.users << @user
-        else
-          domain_match.company.users << @user
-        end
+        company.users << @user
       end
       logger.debug { resp }
       render json: {

--- a/server/features/signup.feature
+++ b/server/features/signup.feature
@@ -110,3 +110,32 @@ Feature: Student signup
     Scenario: Log in as admin
         Given that I log in as admin
         Then I should be logged in
+    
+    Scenario: Signup as company representative
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company domain test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        Then the user with firstname james and lastname bond should be found in the user DB
+        And the company with id 1 should have user with email "test@test.com"
+    
+    Scenario: Signup as student with company ID
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company domain test.com for usertype company representative for company id 1
+        And that I sign up with the following and fail with code 400
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+            | company_id | 1 |
+        Then the user with email test@test.com should NOT be found in the user DB

--- a/server/features/step_definitions/signup.rb
+++ b/server/features/step_definitions/signup.rb
@@ -107,3 +107,9 @@ Then("I should be logged in") do
   ret_body = JSON.parse ret.body
   expect(ret_body["logged_in"]).to be true
 end
+
+Then("the company with id {int} should have user with email {string}") do |company_id, email|
+  user = User.find_by_email(email)
+  company = Company.find(company_id)
+  expect(company.users.include? user).to be true
+end


### PR DESCRIPTION
1. To minimize the change in registration flow, the company will be fetched when checking the allowlist
    1. i.e. The company of a person is set to company of an allowlist entry
2. The `company_id` will be used to check the following, if the company found within the matched allowlist has the same id
    1. If not, bad request error (code:400) is thrown.


Added relevant tests and all tests (previous + new) pass.