### PR TITLE
Primary contact for companies

### DIFF
--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -99,7 +99,11 @@ private
     end
 
     def confirm_requester_is_rep_or_admin()
-        if !(current_user.usertype == "admin" || (current_user.usertype == "company representative" && current_user.company != nil))
+        if !(current_user.usertype == "admin" || 
+            (current_user.usertype == "company representative" && 
+            current_user.company != nil && 
+            current_user.allowlist_email != nil &&
+            current_user.allowlist_email.isPrimaryContact > 0))
           render json: {
             status: 400,
             errors: ["User does not have previleges for requested action"],

--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -11,14 +11,12 @@ class AllowlistDomainsController < ApplicationController
 
            if @domains
               render json: {
-                status: 200,
               domains: @domains
-           }
+           }, status: :ok
           else
               render json: {
-              status: 500,
               errors: ['no domains found']
-          }
+          }, status: :internal_server_error
          end
     end
     
@@ -29,14 +27,12 @@ class AllowlistDomainsController < ApplicationController
         end
            if @domain
               render json: {
-              status: 200,
               domain: @domain
-           }
+           }, status: :ok
            else
               render json: {
-              status: 500,
               errors: ['domain not found']
-            }
+            }, status: :not_found
            end
       end
       
@@ -65,14 +61,12 @@ class AllowlistDomainsController < ApplicationController
             end
 
             render json: {
-            status: 201,
             domain: @domain
-        }
+        }, status: :created
         else 
             render json: {
-            status: 500,
             errors: @domain.errors.full_messages
-        }
+        }, status: :internal_server_error
         end
       end
 
@@ -89,15 +83,13 @@ class AllowlistDomainsController < ApplicationController
             @domain.destroy
 
            render json: {
-            status: 200,
             errors: ['domain deleted']
-            }
+            }, status: :ok
         
         else
            render json: {
-           status: 500,
            errors: ['domain not found']
-            }
+            }, status: :not_found
         end
       end
 
@@ -105,9 +97,8 @@ private
     def confirm_user_logged_in
         if !(logged_in? && current_user)
         render json: {
-            status: 500,
             errors: ["User not logged in"],
-        }
+        }, status: :forbidden
         end
     end
 
@@ -118,9 +109,8 @@ private
             current_user.allowlist_email != nil &&
             current_user.allowlist_email.isPrimaryContact > 0))
           render json: {
-            status: 400,
             errors: ["User does not have previleges for requested action"],
-          }
+          }, status: :forbidden
           return false
         end
         return true

--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -55,6 +55,15 @@ class AllowlistDomainsController < ApplicationController
             if company != nil
                 company.allowlist_domains << @domain
             end
+
+            us = User.where(usertype: @domain.usertype)
+            filter = Regexp.new("@"+@domain.email_domain)
+            for u in us
+                if u != nil && @domain.usertype == u.usertype && u.company == @domain.company && (u.email =~ filter) != nil
+                    @domain.users << u
+                end
+            end
+
             render json: {
             status: 201,
             domain: @domain
@@ -74,7 +83,11 @@ class AllowlistDomainsController < ApplicationController
             @domain=nil
         end
         if @domain 
+
+            @domain.users.where(allowlist_email_id: nil).destroy_all
+            @domain.users.update_all(allowlist_domain_id: nil)
             @domain.destroy
+
            render json: {
             status: 200,
             errors: ['domain deleted']

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -56,6 +56,13 @@ class AllowlistEmailsController < ApplicationController
             if company != nil
                 company.allowlist_emails << @email
             end
+
+            u = User.find_by(email: @email.email)
+            if u != nil && @email.usertype == u.usertype && u.company == @email.company
+                @email.users << u
+            end
+            
+
             render json: {
             status: 201,
             email: @email
@@ -76,7 +83,11 @@ class AllowlistEmailsController < ApplicationController
             @email=nil
         end
         if @email 
+            
+           @email.users.where(allowlist_domain_id: nil).destroy_all
+           @email.users.update_all(allowlist_email_id: nil)
            @email.destroy
+
            render json: {
             status: 200,
             errors: ['email deleted']

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -11,14 +11,12 @@ class AllowlistEmailsController < ApplicationController
 
            if @emails
               render json: {
-                status: 200,
               emails: @emails
-           }
+           }, status: :ok
           else
               render json: {
-              status: 500,
               errors: ['no emails found']
-          }
+          }, status: :internal_server_error
          end
     end
     
@@ -30,14 +28,12 @@ class AllowlistEmailsController < ApplicationController
 
         if @email
             render json: {
-            status: 200,
             email: @email
-        }
+        }, status: :ok
         else
             render json: {
-            status: 500,
             errors: ['email not found']
-        }
+        }, status: :not_found
         end
       end
       
@@ -64,14 +60,12 @@ class AllowlistEmailsController < ApplicationController
             
 
             render json: {
-            status: 201,
             email: @email
-        }
+        }, status: :created
         else 
             render json: {
-            status: 500,
             errors: @email.errors.full_messages
-        }
+        }, status: :internal_server_error
         end
 
       end
@@ -89,15 +83,14 @@ class AllowlistEmailsController < ApplicationController
            @email.destroy
 
            render json: {
-            status: 200,
             errors: ['email deleted']
-            }
+            }, status: :ok
         
         else
            render json: {
            status: 500,
            errors: ['email not found']
-            }
+            }, status: :not_found
         end
       end
 
@@ -123,17 +116,16 @@ class AllowlistEmailsController < ApplicationController
             from_user.usertype != "company representative")
            
             render json: {
-                status: 400,
                 errors: ["User does not have previleges for requested action"],
-            }
+            }, status: :forbidden
             
         else
             to_user.allowlist_email.update(isPrimaryContact: 1)
             from_user.allowlist_email.update(isPrimaryContact: 0)
 
             render json: {
-                status: 200
-            }
+                message: "transfer success"
+            }, status: :ok
         end
 
       end
@@ -142,9 +134,8 @@ private
     def confirm_user_logged_in
         if !(logged_in? && current_user)
         render json: {
-            status: 500,
             errors: ["User not logged in"],
-        }
+        }, status: :forbidden
         end
     end
 
@@ -155,9 +146,8 @@ private
             current_user.allowlist_email != nil &&
             current_user.allowlist_email.isPrimaryContact > 0))
         render json: {
-            status: 400,
             errors: ["User does not have previleges for requested action"],
-        }
+        }, status: :forbidden
         return false
         end
         return true

--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -112,6 +112,11 @@ class UsersController < ApplicationController
       if params["user"]["usertype"] == "company representative"
         company.users << @user
       end
+      if exact_match != nil
+        exact_match.users << @user
+      else
+        domain_match.users << @user
+      end
       logger.debug { resp }
       render json: {
                user: @user,

--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -112,10 +112,10 @@ class UsersController < ApplicationController
       if params["user"]["usertype"] == "company representative"
         company.users << @user
       end
-      if exact_match != nil
+      if exact_match != nil and company == exact_match.company
         exact_match.users << @user
       end
-      if domain_match != nil
+      if domain_match != nil and company == domain_match.company
         domain_match.users << @user
       end
       logger.debug { resp }

--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -114,7 +114,8 @@ class UsersController < ApplicationController
       end
       if exact_match != nil
         exact_match.users << @user
-      else
+      end
+      if domain_match != nil
         domain_match.users << @user
       end
       logger.debug { resp }

--- a/server/app/models/allowlist_domain.rb
+++ b/server/app/models/allowlist_domain.rb
@@ -6,4 +6,6 @@ class AllowlistDomain < ApplicationRecord
     :inclusion  => { :in => [ 'company representative', 'student', 'faculty', 'admin', 'volunteer'],
                      :message    => "%{value} is not a valid usertype" }
     belongs_to :company, optional: true
+
+    has_many :users, dependent: :destroy
 end

--- a/server/app/models/allowlist_domain.rb
+++ b/server/app/models/allowlist_domain.rb
@@ -7,5 +7,5 @@ class AllowlistDomain < ApplicationRecord
                      :message    => "%{value} is not a valid usertype" }
     belongs_to :company, optional: true
 
-    has_many :users, dependent: :destroy
+    has_many :users#, dependent: :destroy_if_not_allowed
 end

--- a/server/app/models/allowlist_email.rb
+++ b/server/app/models/allowlist_email.rb
@@ -6,4 +6,6 @@ class AllowlistEmail < ApplicationRecord
     :inclusion  => { :in => [ 'company representative', 'student', 'faculty', 'admin', 'volunteer'],
                      :message    => "%{value} is not a valid usertype" }
     belongs_to :company, optional: true
+
+    has_many :users, dependent: :destroy
 end

--- a/server/app/models/allowlist_email.rb
+++ b/server/app/models/allowlist_email.rb
@@ -7,5 +7,5 @@ class AllowlistEmail < ApplicationRecord
                      :message    => "%{value} is not a valid usertype" }
     belongs_to :company, optional: true
 
-    has_many :users, dependent: :destroy
+    has_many :users#, dependent: :destroy_if_not_allowed
 end

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -17,6 +17,9 @@ class User < ApplicationRecord
   has_many :user_meetings, dependent: :destroy
   has_many :invited_meetings, through: :user_meetings, source: :meeting
 
+  belongs_to :allowlist_domain, optional: true
+  belongs_to :allowlist_email, optional: true
+
   def as_json(options = {})
     options[:except] ||= [:password_digest]
     super(options)

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   # Allowlist routes
   resources :allowlist_domains, only: [:create, :show, :index, :destroy] 
   resources :allowlist_emails, only: [:create, :show, :index, :destroy] 
-  post "/allowlist_emails/transferPrimaryContact", to: "allowlist_emails#transferPrimaryContact"
+  post "/allowlist_emails/transfer_primary_contact", to: "allowlist_emails#transferPrimaryContact"
 
 
   get "/users/:id/meetings", to: "users#get_meetings"

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   # Allowlist routes
   resources :allowlist_domains, only: [:create, :show, :index, :destroy] 
   resources :allowlist_emails, only: [:create, :show, :index, :destroy] 
+  post "/allowlist_emails/transferPrimaryContact", to: "allowlist_emails#transferPrimaryContact"
 
 
   get "/users/:id/meetings", to: "users#get_meetings"

--- a/server/db/migrate/20221103043751_add_primary_contact_to_email_allowlist.rb
+++ b/server/db/migrate/20221103043751_add_primary_contact_to_email_allowlist.rb
@@ -1,0 +1,7 @@
+class AddPrimaryContactToEmailAllowlist < ActiveRecord::Migration[7.0]
+  def change
+    add_column :allowlist_emails, :isPrimaryContact, :boolean, :default => 0
+    add_reference :users, :allowlist_email, foreign_key: true
+    add_reference :users, :allowlist_domain, foreign_key: true
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_21_071837) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_03_043751) do
   create_table "allowlist_domains", force: :cascade do |t|
     t.string "email_domain"
     t.string "usertype"
@@ -19,15 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_071837) do
     t.index ["email_domain", "usertype"], name: "index_allowlist_domains_on_email_domain_and_usertype", unique: true
   end
 
-  create_table "allowlist_emails", force: :cascade do |t|
-    t.string "email"
-    t.string "usertype"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "company_id"
-    t.index ["company_id"], name: "index_allowlist_emails_on_company_id"
-    t.index ["email", "usertype"], name: "index_allowlist_emails_on_email_and_usertype", unique: true
-  end
+# Could not dump table "allowlist_emails" because of following StandardError
+#   Unknown type 'bool' for column 'isPrimaryContact'
 
   create_table "companies", force: :cascade do |t|
     t.string "name"
@@ -74,6 +67,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_071837) do
     t.string "firstname"
     t.string "lastname"
     t.integer "company_id"
+    t.integer "allowlist_email_id"
+    t.integer "allowlist_domain_id"
+    t.index ["allowlist_domain_id"], name: "index_users_on_allowlist_domain_id"
+    t.index ["allowlist_email_id"], name: "index_users_on_allowlist_email_id"
     t.index ["company_id"], name: "index_users_on_company_id"
   end
 
@@ -82,5 +79,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_071837) do
   add_foreign_key "meetings", "users", column: "owner_id"
   add_foreign_key "user_meetings", "meetings"
   add_foreign_key "user_meetings", "users"
+  add_foreign_key "users", "allowlist_domains"
+  add_foreign_key "users", "allowlist_emails"
   add_foreign_key "users", "companies"
 end

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -26,6 +26,21 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | student |
         Then the user with firstname james and lastname bond should be found in the user DB
+
+    Scenario: A student signs up to a newly allowed domain, which is then deleted
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        Then the user with firstname james and lastname bond should be found in the user DB
+        Given that I log in as admin
+        And I delete the allowed domain with index 4
+        Then the user with firstname james and lastname bond should NOT be found in the user DB
             
     Scenario: A student signs up to a disallowed domain
         Given that I log in as admin
@@ -105,6 +120,21 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | student |
         Then the user with firstname james and lastname bond should be found in the user DB
+
+    Scenario: A student signs up to a newly allowed email, which is then deleted
+        Given that I log in as admin
+        And I allow a new email test@test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        Then the user with firstname james and lastname bond should be found in the user DB
+        Given that I log in as admin
+        And I delete the allowed email with index 1
+        Then the user with firstname james and lastname bond should NOT be found in the user DB
             
     Scenario: A student signs up to a disallowed email
         Given that I log in as admin

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -447,3 +447,72 @@ Feature: Allowlist Management
         And I should get a 400 code from the email database
         And that I log in as admin
         And I fail to transfer primary contact role to user with id 3 from user with id 2
+
+    Scenario: A student signs up to a newly allowed email and email, which is then deleted, but he remains
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        Given that I log in as admin
+        And I allow a new email test@test.com for usertype student
+        Then the user with firstname james and lastname bond should be found in the user DB
+        Given that I log in as admin
+        And I delete the allowed email with index 1
+        Then the user with firstname james and lastname bond should be found in the user DB
+
+    Scenario: A student signs up to a newly allowed email and email, which is then deleted, but he remains
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        Given that I log in as admin
+        And I allow a new email test@test.com for usertype student
+        Then the user with firstname james and lastname bond should be found in the user DB
+        Given that I log in as admin
+        And I delete the allowed domain with index 4
+        Then the user with firstname james and lastname bond should be found in the user DB
+
+        
+    Scenario: A student signs up to a newly allowed email and email, which is then deleted, but he remains
+        Given that I log in as admin
+        And I allow a new email test@test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype student
+        Then the user with firstname james and lastname bond should be found in the user DB
+        Given that I log in as admin
+        And I delete the allowed email with index 1
+        Then the user with firstname james and lastname bond should be found in the user DB
+
+    Scenario: A student signs up to a newly allowed email and email, which is then deleted, but he remains
+        Given that I log in as admin
+        And I allow a new email test@test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype student
+        Then the user with firstname james and lastname bond should be found in the user DB
+        Given that I log in as admin
+        And I delete the allowed domain with index 4
+        Then the user with firstname james and lastname bond should be found in the user DB

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -265,8 +265,8 @@ Feature: Allowlist Management
             | usertype | company representative |
             | company_id | 1 |
         And that I log in with email test@test.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
         And that I sign up with the following
             | firstname | james |
             | lastname | bond |
@@ -276,8 +276,8 @@ Feature: Allowlist Management
             | usertype | company representative |
             | company_id | 2 |
         And that I log in with email test2@test2.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
 
 
     Scenario: Multiple company emails are added and only appropriate users can see them
@@ -296,8 +296,8 @@ Feature: Allowlist Management
             | usertype | company representative |
             | company_id | 1 |
         And that I log in with email test@test.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
 
     Scenario: A rep transfers primary contact correctly
         Given that I log in as admin
@@ -323,12 +323,12 @@ Feature: Allowlist Management
         And that I log in with email test@test.com and password password1!
         Then I should see 2 new email in the database
         And that I log in with email test2@test.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
         And that I log in with email test@test.com and password password1!
         And I transfer my primary contact role to user with id 3
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
         And that I log in with email test2@test.com and password password1!
         Then I should see 2 new email in the database
 
@@ -357,13 +357,13 @@ Feature: Allowlist Management
         And that I log in with email test@test.com and password password1!
         Then I should see 2 new email in the database
         And that I log in with email test2@test.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
         And that I log in as admin
         And I transfer primary contact role to user with id 3 from user with id 2
         And that I log in with email test@test.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
         And that I log in with email test2@test.com and password password1!
         Then I should see 2 new email in the database
 
@@ -443,8 +443,8 @@ Feature: Allowlist Management
         And that I log in with email test@test.com and password password1!
         Then I should see 1 new email in the database
         And that I log in with email test2@test.com and password password1!
-        Then I should get a 400 code from the domain database
-        And I should get a 400 code from the email database
+        Then I should get a 403 code from the domain database
+        And I should get a 403 code from the email database
         And that I log in as admin
         And I fail to transfer primary contact role to user with id 3 from user with id 2
 

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -53,18 +53,19 @@ Feature: Allowlist Management
     Scenario: A company rep adds an allowed domain
         Given that I log in as admin
         And there is a company with id 1
-        And I allow a new company domain test.com for usertype company representative for company id 1
-        And that I sign up with the following to company id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And that I sign up with the following
             | firstname | james |
             | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test@test.com |
             | usertype | company representative |
+            | company_id | 1 |
         And that I log in with email test@test.com and password password1!
         And I allow a new domain test2.com for usertype company representative
         And that I log in as admin
-        Then I should see 5 domain in the database
+        Then I should see 4 domain in the database
         And the company with id 1 should have 1 reps
         
     Scenario: Log in as admin and create a new email allowed
@@ -72,6 +73,20 @@ Feature: Allowlist Management
         And I allow a new email test@test.com for usertype student
         Then I should see 1 new email in the database
         And I should see an email with index 1 in the database
+
+    Scenario: Log in as admin and create a new email allowed
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company email test@test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        Then the user with firstname james and lastname bond should be found in the user DB
 
     Scenario: Log in as admin and create a new email allowed and then delete it
         Given that I log in as admin
@@ -117,23 +132,25 @@ Feature: Allowlist Management
     Scenario: A company rep adds an allowed email
         Given that I log in as admin
         And there is a company with id 1
-        And I allow a new company email test@test.com for usertype company representative for company id 1
-        And that I sign up with the following to company id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And that I sign up with the following
             | firstname | james |
             | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test@test.com |
             | usertype | company representative |
+            | company_id | 1 |
         And that I log in with email test@test.com and password password1!
         And I allow a new email test2@test2.com for usertype company representative
-        And that I sign up with the following to company id 1
-            | firstname | james2 |
-            | lastname | bond2 |
+            And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test2@test2.com |
             | usertype | company representative |
+            | company_id | 1 |
         And that I log in as admin
         Then I should see 2 new email in the database
         And the company with id 1 should have 2 reps
@@ -142,25 +159,27 @@ Feature: Allowlist Management
         Given that I log in as admin
         And there is a company with id 1
         And there is a company with id 2
-        And I allow a new company email test@test.com for usertype company representative for company id 1
-        And I allow a new company email test2@test2.com for usertype company representative for company id 2
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new primary contact company email test2@test2.com for usertype company representative for company id 2
         And I allow a new company email test3@test3.com for usertype company representative for company id 2
-        And that I sign up with the following to company id 1
+        And that I sign up with the following
             | firstname | james |
             | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test@test.com |
             | usertype | company representative |
+            | company_id | 1 |
         And that I log in with email test@test.com and password password1!
         Then I should see 1 new email in the database
-        And that I sign up with the following to company id 2
+        And that I sign up with the following
             | firstname | james |
             | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test2@test2.com |
             | usertype | company representative |
+            | company_id | 2 |
         And that I log in with email test2@test2.com and password password1!
         Then I should see 2 new email in the database
         And I should see an email with index 2 in the database
@@ -174,23 +193,227 @@ Feature: Allowlist Management
         And I allow a new company domain test.com for usertype company representative for company id 1
         And I allow a new company domain test2.com for usertype company representative for company id 2
         And I allow a new company domain test3.com for usertype company representative for company id 2
-        And that I sign up with the following to company id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new primary contact company email test2@test2.com for usertype company representative for company id 2
+        And that I sign up with the following
             | firstname | james |
             | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test@test.com |
             | usertype | company representative |
+            | company_id | 1 |
         And that I log in with email test@test.com and password password1!
         Then I should see 1 domain in the database
-        And that I sign up with the following to company id 2
+        And that I sign up with the following
             | firstname | james |
             | lastname | bond |
             | password | password1! |
             | password_confirmation | password1! |
             | email | test2@test2.com |
             | usertype | company representative |
+            | company_id | 2 |
         And that I log in with email test2@test2.com and password password1!
         Then I should see 2 domain in the database
         And I should see a domain with index 5 in the database
         And I should see a domain with index 6 in the database
+
+            
+    Scenario: Multiple company emails are added and only appropriate users can see them
+        Given that I log in as admin
+        And there is a company with id 1
+        And there is a company with id 2
+        And I allow a new company domain test.com for usertype company representative for company id 1
+        And I allow a new company domain test2.com for usertype company representative for company id 2
+        And I allow a new company domain test3.com for usertype company representative for company id 2
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in with email test@test.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test2.com |
+            | usertype | company representative |
+            | company_id | 2 |
+        And that I log in with email test2@test2.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+
+
+    Scenario: Multiple company emails are added and only appropriate users can see them
+        Given that I log in as admin
+        And there is a company with id 1
+        And there is a company with id 2
+        And I allow a new company domain test0.com for usertype company representative for company id 1
+        And I allow a new company domain test02.com for usertype company representative for company id 2
+        And I allow a new company email test@test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in with email test@test.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+
+    Scenario: A rep transfers primary contact correctly
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new company email test2@test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in with email test@test.com and password password1!
+        Then I should see 2 new email in the database
+        And that I log in with email test2@test.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+        And that I log in with email test@test.com and password password1!
+        And I transfer my primary contact role to user with id 3
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+        And that I log in with email test2@test.com and password password1!
+        Then I should see 2 new email in the database
+
+
+    Scenario: An admin transfers primary contact correctly
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new company email test2@test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in with email test@test.com and password password1!
+        Then I should see 2 new email in the database
+        And that I log in with email test2@test.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+        And that I log in as admin
+        And I transfer primary contact role to user with id 3 from user with id 2
+        And that I log in with email test@test.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+        And that I log in with email test2@test.com and password password1!
+        Then I should see 2 new email in the database
+
+    Scenario: A rep fails  to transfer primary contact
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company email test@test.com for usertype company representative for company id 1
+        And I allow a new company email test2@test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in with email test@test.com and password password1!
+        And I fail to transfer my primary contact role to user with id 3
+
+
+    Scenario: An admin transfers primary contact incorrectly
+        Given that I log in as admin
+        And there is a company with id 1
+        And there is a company with id 2
+        And I allow a new company email test@test.com for usertype company representative for company id 1
+        And I allow a new company email test2@test.com for usertype company representative for company id 1
+        And I allow a new company email test3@test.com for usertype company representative for company id 2
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in as admin
+        And I fail to transfer primary contact role to user with id 3 from user with id 2
+
+   Scenario: An admin transfers primary contact incorrectly
+        Given that I log in as admin
+        And there is a company with id 1
+        And there is a company with id 2
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new company email test2@test.com for usertype company representative for company id 2
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test.com |
+            | usertype | company representative |
+            | company_id | 2 |
+        And that I log in with email test@test.com and password password1!
+        Then I should see 1 new email in the database
+        And that I log in with email test2@test.com and password password1!
+        Then I should get a 400 code from the domain database
+        And I should get a 400 code from the email database
+        And that I log in as admin
+        And I fail to transfer primary contact role to user with id 3 from user with id 2

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -6,13 +6,6 @@ Given ('there is a company with id {int}') do |int|
     ret.save!
 end
 
-Given("that I sign up with the following to company id {int}") do |int, table|
-    c = Company.find_by_id(int)
-    u = User.new(table.rows_hash)
-    u.save!
-    c.users << u
-end
-
 Then('the company with id {int} should have {int} reps') do |id, int|
     c = Company.find_by_id(id)
     expect(c.users.size).to eq(int)
@@ -60,6 +53,12 @@ Given /^I allow a new company email ([^\']*) for usertype ([^\']*) for company i
     expect(ret_body['status']).to eq(201)
 end
 
+Given /^I allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
+    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int, "isPrimaryContact":1}})
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(201)
+end
+
 Given /^I delete the allowed email with index 1$/ do 
     ret = page.driver.delete('/allowlist_emails/1')
     ret_body = JSON.parse ret.body
@@ -76,4 +75,40 @@ Then('I should see an email with index {int} in the database') do |int|
     ret = page.driver.get('/allowlist_emails/' + int.to_s)
     ret_body = JSON.parse ret.body
     expect(ret_body['status']).to eq(200)
+end
+
+Then('I should get a {int} code from the email database') do |int|
+    ret = page.driver.get('/allowlist_emails')
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(int)
+end
+
+Then('I should get a {int} code from the domain database') do |int|
+    ret = page.driver.get('/allowlist_domains')
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(int)
+end
+
+Given('I transfer my primary contact role to user with id {int}') do |int|
+    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int})
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(200)
+end
+
+Given('I transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
+    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int1, "from":int2})
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(200)
+end
+
+Given('I fail to transfer my primary contact role to user with id {int}') do |int|
+    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int})
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(400)
+end
+
+Given('I fail to transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
+    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int1, "from":int2})
+    ret_body = JSON.parse ret.body
+    expect(ret_body['status']).to eq(400)
 end

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -14,19 +14,19 @@ Then('the company with id {int} should have {int} reps') do |id, int|
 Given /^I allow a new domain ([^\']*) for usertype ([^\']*)$/ do |domain, usertype|
   ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype}})
   ret_body = JSON.parse ret.body
-  expect(ret_body['status']).to eq(201)
+  expect(ret.status).to eq(201)
 end
 
 Given /^I allow a new company domain ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |domain, usertype, int|
     ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(201)
+    expect(ret.status).to eq(201)
 end
 
 Given /^I delete the allowed domain with index 4$/ do 
     ret = page.driver.delete('/allowlist_domains/4')
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(200)
+    expect(ret.status).to eq(200)
 end
 
 Then('I should see {int} domain in the database') do |int|
@@ -38,31 +38,31 @@ end
 Then('I should see a domain with index {int} in the database') do |int|
     ret = page.driver.get('/allowlist_domains/' + int.to_s)
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(200)
+    expect(ret.status).to eq(200)
   end
 
 Given /^I allow a new email ([^\']*) for usertype ([^\']*)$/ do |email, usertype|
     ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype}})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(201)
+    expect(ret.status).to eq(201)
 end
 
 Given /^I allow a new company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
     ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(201)
+    expect(ret.status).to eq(201)
 end
 
 Given /^I allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
     ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int, "isPrimaryContact":1}})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(201)
+    expect(ret.status).to eq(201)
 end
 
 Given /^I delete the allowed email with index 1$/ do 
     ret = page.driver.delete('/allowlist_emails/1')
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(200)
+    expect(ret.status).to eq(200)
 end
 
 Then('I should see {int} new email in the database') do |int|
@@ -74,41 +74,41 @@ end
 Then('I should see an email with index {int} in the database') do |int|
     ret = page.driver.get('/allowlist_emails/' + int.to_s)
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(200)
+    expect(ret.status).to eq(200)
 end
 
 Then('I should get a {int} code from the email database') do |int|
     ret = page.driver.get('/allowlist_emails')
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(int)
+    expect(ret.status).to eq(int)
 end
 
 Then('I should get a {int} code from the domain database') do |int|
     ret = page.driver.get('/allowlist_domains')
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(int)
+    expect(ret.status).to eq(int)
 end
 
 Given('I transfer my primary contact role to user with id {int}') do |int|
     ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(200)
+    expect(ret.status).to eq(200)
 end
 
 Given('I transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
     ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int1, "from":int2})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(200)
+    expect(ret.status).to eq(200)
 end
 
 Given('I fail to transfer my primary contact role to user with id {int}') do |int|
     ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(400)
+    expect(ret.status).to eq(403)
 end
 
 Given('I fail to transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
     ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int1, "from":int2})
     ret_body = JSON.parse ret.body
-    expect(ret_body['status']).to eq(400)
+    expect(ret.status).to eq(403)
 end

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -90,25 +90,25 @@ Then('I should get a {int} code from the domain database') do |int|
 end
 
 Given('I transfer my primary contact role to user with id {int}') do |int|
-    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int})
+    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(200)
 end
 
 Given('I transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
-    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int1, "from":int2})
+    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int1, "from":int2})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(200)
 end
 
 Given('I fail to transfer my primary contact role to user with id {int}') do |int|
-    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int})
+    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(403)
 end
 
 Given('I fail to transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
-    ret = page.driver.post('/allowlist_emails/transferPrimaryContact', {"to":int1, "from":int2})
+    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int1, "from":int2})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(403)
 end


### PR DESCRIPTION
Added features for companies to reference primary contacts

Changes:
- Users now have a foreign key to allowlist_emails and allowlist_domains
- Allowlist_emails now has a bool marking a user as a primary contact
- Primary contacts must be allowed by an admin
- If a user is a primary contact, they may transfer that role to another company rep for their company
- Admins can transfer company rep status between users of a company
- If an allowlist is deleted, users that are no longer allowed by any allowlist are deleted

Route changes:
- allowlist routes are only available to primary contacts and admins
- POST /allowlist_emails/transfer_primary_contact with {'to':user_id, 'from': user_id} transers primary contact. Usable by admins (needs to and from) and existing primary contacts (needs only to). 
- Post /allowlist_emails (creating a new allowlist) now has an additional param, isPrimaryContact, which should be 0 or 1.