### PR TITLE
Filtered allowlist routes

### DIFF
--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -9,15 +9,23 @@ class AllowlistDomainsController < ApplicationController
             @domains = @domains.filter {|e| e.company == current_user.company}
         end
 
-           if @domains
-              render json: {
-              domains: @domains
-           }, status: :ok
-          else
-              render json: {
-              errors: ['no domains found']
-          }, status: :internal_server_error
-         end
+        if params[:usertype] != nil
+            @domains = @domains.where(usertype: params[:usertype])
+        end
+
+        if params[:company_id] != nil
+            @domains = @domains.where(company_id: params[:company_id])
+        end
+
+        if @domains
+            render json: {
+            domains: @domains
+        }, status: :ok
+        else
+            render json: {
+            errors: ['no domains found']
+        }, status: :internal_server_error
+        end
     end
     
     def show
@@ -25,16 +33,16 @@ class AllowlistDomainsController < ApplicationController
         if current_user.usertype == "company representative" and @domain.company_id != current_user.company_id
             @domain=nil
         end
-           if @domain
-              render json: {
-              domain: @domain
-           }, status: :ok
-           else
-              render json: {
-              errors: ['domain not found']
-            }, status: :not_found
-           end
-      end
+        if @domain
+            render json: {
+            domain: @domain
+        }, status: :ok
+        else
+            render json: {
+            errors: ['domain not found']
+        }, status: :not_found
+        end
+    end
       
       def create
 

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -9,15 +9,23 @@ class AllowlistEmailsController < ApplicationController
             @emails = @emails.filter {|e| e.company == current_user.company}
         end
 
-           if @emails
-              render json: {
-              emails: @emails
-           }, status: :ok
-          else
-              render json: {
-              errors: ['no emails found']
-          }, status: :internal_server_error
-         end
+        if params[:usertype] != nil
+            @emails = @emails.where(usertype: params[:usertype])
+        end
+
+        if params[:company_id] != nil
+            @emails = @emails.where(company_id: params[:company_id])
+        end
+
+        if @emails
+            render json: {
+            emails: @emails
+        }, status: :ok
+        else
+            render json: {
+            errors: ['no emails found']
+        }, status: :internal_server_error
+        end
     end
     
     def show

--- a/server/app/controllers/companies_controller.rb
+++ b/server/app/controllers/companies_controller.rb
@@ -2,9 +2,21 @@ class CompaniesController < ApplicationController
   def index
     # Displays all companies
     @companies = Company.all
-    render json: {
-             companies: @companies,
-           }, status: :ok
+
+    include_ = []
+    p "LOGGED IN?"
+    p logged_in?
+    p current_user
+    if logged_in? && current_user && current_user.usertype == "admin"
+      p "LOGGED IN!"
+      include_ = ["allowlist_domains", "allowlist_emails"]
+    end
+    p "HERE"
+
+    # render json: {
+    #          companies: @companies, include: include_,
+    #        }, status: :ok
+    render :json=> {companies: @companies}.to_json(include: include_), status: :ok
   end
 
   def new

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -536,3 +536,29 @@ Feature: Allowlist Management
         Then I should see 3 new email in the database
         And I should see 0 email with usertype: student in the database
         And I should see 1 email with company_id: 1 in the database
+
+    Scenario: Companies is joined on allowlist for an admin        
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company email test@test1.com for usertype company representative for company id 1
+        And I allow a new company email test@test2.com for usertype company representative for company id 1
+        And I allow a new company domain test3.com for usertype company representative for company id 1
+        Then I should see allowlist emails and domains in company 1 when indexing
+
+    Scenario: Companies is not joined on allowlist for an admin        
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company email test@test1.com for usertype company representative for company id 1
+        And I allow a new company email test@test2.com for usertype company representative for company id 1
+        And I allow a new company domain test3.com for usertype company representative for company id 1
+        And I allow a new domain test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | student |
+        And that I log in with email test@test.com and password password1!
+        Then I should not see allowlist emails and domains in company 1 when indexing
+        And that I log out

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -516,3 +516,23 @@ Feature: Allowlist Management
         Given that I log in as admin
         And I delete the allowed domain with index 4
         Then the user with firstname james and lastname bond should be found in the user DB
+
+    Scenario: Filter domain allowlist
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype admin
+        And I allow a new domain test2.com for usertype admin
+        And there is a company with id 1
+        And I allow a new company domain test3.com for usertype company representative for company id 1
+        Then I should see 6 domain in the database
+        And I should see 3 domain with usertype: student in the database
+        And I should see 1 domain with company_id: 1 in the database
+
+    Scenario: Filter email allowlist
+        Given that I log in as admin
+        And I allow a new email 1@test.com for usertype admin
+        And I allow a new email 1@test2.com for usertype admin
+        And there is a company with id 1
+        And I allow a new company email test@test3.com for usertype company representative for company id 1
+        Then I should see 3 new email in the database
+        And I should see 0 email with usertype: student in the database
+        And I should see 1 email with company_id: 1 in the database

--- a/server/features/company.feature
+++ b/server/features/company.feature
@@ -1,12 +1,15 @@
 Feature: admin can CRUD a company object/account
+    In order to manage who can make an account
+    As an admin
+    I want to controll access with an allowlist
 
-# create
-Scenario: admin can create a new company by providing its name, description
-      Given name as a string and description as a text
-      Then 1 company should be in company DB
-Scenario: admin can create a new company by just providing its name
-      Given name as a string
-      Then 1 new company with the specified name will be created in the database
-Scenario: admin cannot create a new company without providing its name
-      Given name not provided
-      Then an error page is shown
+    Scenario: admin can create a new company by providing its name, description
+        Given name as a string and description as a text
+        Then 1 company should be in company DB
+        
+    Scenario: admin can create a new company by just providing its name
+        Given name as a string
+        Then 1 new company with the specified name will be created in the database
+        Scenario: admin cannot create a new company without providing its name
+        Given name not provided
+        Then an error page is shown

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -35,6 +35,18 @@ Then('I should see {int} domain in the database') do |int|
   expect(ret_body['domains'].size).to eq(int)
 end
 
+Then("I should see {int} domain with usertype: student in the database") do |int|
+    ret = page.driver.get("/allowlist_domains/?usertype=student")
+    ret_body = JSON.parse ret.body
+    expect(ret_body['domains'].size).to eq(int)
+end
+
+Then("I should see {int} domain with company_id: 1 in the database") do |int|
+    ret = page.driver.get("/allowlist_domains/?company_id=1")
+    ret_body = JSON.parse ret.body
+    expect(ret_body['domains'].size).to eq(int)
+end
+
 Then('I should see a domain with index {int} in the database') do |int|
     ret = page.driver.get('/allowlist_domains/' + int.to_s)
     ret_body = JSON.parse ret.body
@@ -69,6 +81,18 @@ Then('I should see {int} new email in the database') do |int|
 ret = page.driver.get('/allowlist_emails')
 ret_body = JSON.parse ret.body
 expect(ret_body['emails'].size).to eq(int)
+end
+
+Then('I should see {int} email with usertype: student in the database') do |int|
+    ret = page.driver.get('/allowlist_emails/?usertype=student')
+    ret_body = JSON.parse ret.body
+    expect(ret_body['emails'].size).to eq(int)
+end
+
+Then('I should see {int} email with company_id: 1 in the database') do |int|
+    ret = page.driver.get('/allowlist_emails/?company_id=1')
+    ret_body = JSON.parse ret.body
+    expect(ret_body['emails'].size).to eq(int)
 end
 
 Then('I should see an email with index {int} in the database') do |int|

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -136,3 +136,23 @@ Given('I fail to transfer primary contact role to user with id {int} from user w
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(403)
 end
+
+Then("I should see allowlist emails and domains in company 1 when indexing") do
+    ret = page.driver.get("/companies")
+    ret_body = JSON.parse ret.body
+    ae = ret_body["companies"][0]["allowlist_emails"]
+    ad = ret_body["companies"][0]["allowlist_domains"]
+    p ret_body
+    expect(ae.size > 0).to eq(true)
+    expect(ad.size > 0).to eq(true)
+end
+
+Then("I should not see allowlist emails and domains in company 1 when indexing") do
+    ret = page.driver.get("/companies")
+    ret_body = JSON.parse ret.body
+    ae = ret_body["companies"][0]["allowlist_emails"]
+    ad = ret_body["companies"][0]["allowlist_domains"]
+    p ret_body
+    expect(ae).to eq(nil)
+    expect(ad).to eq(nil)
+end


### PR DESCRIPTION
Adds routes to index allowlists on usertype and/or company_id, and updates companies route

Routes:
- GET /companies will be joined on the domain and email allowlists if the user is an admin
  - Does not join for company PCs - they can use the below routes to get the same info, since they are filtered to their companies' allowlists as is
- GET /allowlist_emails and /allowlist_domains now take optional parameters usertype and company_id