### PR TITLE
Allowlist uniqueness

### DIFF
--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -54,6 +54,7 @@ class AllowlistDomainsController < ApplicationController
     end
 
     @domain = AllowlistDomain.new(domain_params)
+    @domain.company_id = company ? company.id : nil
     if @domain.save
       if company != nil
         company.allowlist_domains << @domain
@@ -124,6 +125,9 @@ class AllowlistDomainsController < ApplicationController
   def domain_params
     if params[:domain] != nil && params[:domain][:email_domain] != nil
       params[:domain][:email_domain] = params[:domain][:email_domain].downcase
+    end
+    if @current_user.usertype != "admin"
+      params[:domain][:usertype] = "company representative"
     end
     params.require(:domain).permit(:email_domain, :usertype)
   end

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -55,6 +55,7 @@ class AllowlistEmailsController < ApplicationController
     end
 
     @email = AllowlistEmail.new(email_params)
+    @email.company_id = company ? company.id : nil
     if @email.save
       if company != nil
         company.allowlist_emails << @email
@@ -158,6 +159,7 @@ class AllowlistEmailsController < ApplicationController
     end
     if @current_user.usertype != "admin"
       params[:email][:isPrimaryContact] = false
+      params[:email][:usertype] = "company representative"
     end
     params.require(:email).permit(:email, :usertype, :isPrimaryContact)
   end

--- a/server/app/controllers/companies_controller.rb
+++ b/server/app/controllers/companies_controller.rb
@@ -4,18 +4,10 @@ class CompaniesController < ApplicationController
     @companies = Company.all
 
     include_ = []
-    p "LOGGED IN?"
-    p logged_in?
-    p current_user
     if logged_in? && current_user && current_user.usertype == "admin"
-      p "LOGGED IN!"
       include_ = ["allowlist_domains", "allowlist_emails"]
     end
-    p "HERE"
 
-    # render json: {
-    #          companies: @companies, include: include_,
-    #        }, status: :ok
     render :json=> {companies: @companies}.to_json(include: include_), status: :ok
   end
 

--- a/server/app/controllers/sessions_controller.rb
+++ b/server/app/controllers/sessions_controller.rb
@@ -12,12 +12,12 @@ class SessionsController < ApplicationController
       else
         render json: {
           errors: ["email not confirmed"],
-        }, status: :forbidden
+        }, status: :unauthorized
       end
     else
       render json: {
                errors: ["no such user, please try again"],
-             }, status: :forbidden
+             }, status: :unauthorized
     end
   end
 

--- a/server/app/controllers/sessions_controller.rb
+++ b/server/app/controllers/sessions_controller.rb
@@ -3,11 +3,18 @@ class SessionsController < ApplicationController
     @user = User.find_by(email: session_params[:email])
 
     if @user && @user.authenticate(session_params[:password])
-      login!
-      render json: {
-               logged_in: true,
-               user: @user,
-             }
+      if @user.email_confirmed
+        login!
+        render json: {
+                logged_in: true,
+                user: @user,
+              }
+      else
+        render json: {
+          status: 401,
+          errors: ["email not confirmed"],
+        }
+      end
     else
       render json: {
                status: 401,

--- a/server/app/controllers/sessions_controller.rb
+++ b/server/app/controllers/sessions_controller.rb
@@ -8,18 +8,16 @@ class SessionsController < ApplicationController
         render json: {
                 logged_in: true,
                 user: @user,
-              }
+              }, status: :ok
       else
         render json: {
-          status: 401,
           errors: ["email not confirmed"],
-        }
+        }, status: :forbidden
       end
     else
       render json: {
-               status: 401,
                errors: ["no such user, please try again"],
-             }
+             }, status: :forbidden
     end
   end
 
@@ -28,21 +26,20 @@ class SessionsController < ApplicationController
       render json: {
                logged_in: true,
                user: current_user,
-             }
+             }, status: :ok
     else
       render json: {
                logged_in: false,
                message: "no such user",
-             }
+             }, status: :ok
     end
   end
 
   def destroy
     logout!
     render json: {
-             status: 200,
              logged_out: true,
-           }
+           }, status: :ok
   end
 
   private

--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -107,7 +107,6 @@ class UsersController < ApplicationController
 
     @user = User.new(user_params)
     if @user.save
-      login!
       resp = UserMailer.registration_confirmation(@user).deliver_now
       if params["user"]["usertype"] == "company representative"
         company.users << @user

--- a/server/app/models/allowlist_domain.rb
+++ b/server/app/models/allowlist_domain.rb
@@ -1,6 +1,6 @@
 class AllowlistDomain < ApplicationRecord
     validates :email_domain, presence: true
-    validates :email_domain, uniqueness: { scope: :usertype }
+    validates :email_domain, uniqueness: { scope: [:usertype, :company_id] }
     validates :email_domain, format: { with: /\A((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
     validates :usertype,
     :inclusion  => { :in => [ 'company representative', 'student', 'faculty', 'admin', 'volunteer'],

--- a/server/app/models/allowlist_email.rb
+++ b/server/app/models/allowlist_email.rb
@@ -1,6 +1,6 @@
 class AllowlistEmail < ApplicationRecord
     validates :email, presence: true
-    validates :email, uniqueness: { scope: :usertype }
+    validates :email, uniqueness: { scope: [:usertype, :company_id] }
     validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
     validates :usertype,
     :inclusion  => { :in => [ 'company representative', 'student', 'faculty', 'admin', 'volunteer'],

--- a/server/db/migrate/20221115192645_allowlist_uniqueness_on_company_email_usertype.rb
+++ b/server/db/migrate/20221115192645_allowlist_uniqueness_on_company_email_usertype.rb
@@ -1,0 +1,10 @@
+class AllowlistUniquenessOnCompanyEmailUsertype < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :allowlist_domains, name:"index_allowlist_domains_on_email_domain_and_usertype"
+    remove_index :allowlist_emails, name:"index_allowlist_emails_on_email_and_usertype"
+
+    add_index :allowlist_domains, [:email_domain, :usertype, :company_id], unique: true, name: "domain_usertype_company"
+    add_index :allowlist_emails, [:email, :usertype, :company_id], unique: true, name: "email_usertype_company"
+
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_022906) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_15_192645) do
   create_table "allowlist_domains", force: :cascade do |t|
     t.string "email_domain"
     t.string "usertype"
     t.integer "company_id"
     t.index ["company_id"], name: "index_allowlist_domains_on_company_id"
-    t.index ["email_domain", "usertype"], name: "index_allowlist_domains_on_email_domain_and_usertype", unique: true
+    t.index ["email_domain", "usertype", "company_id"], name: "domain_usertype_company", unique: true
   end
 
   create_table "allowlist_emails", force: :cascade do |t|
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_04_022906) do
     t.integer "company_id"
     t.boolean "isPrimaryContact", default: false
     t.index ["company_id"], name: "index_allowlist_emails_on_company_id"
-    t.index ["email", "usertype"], name: "index_allowlist_emails_on_email_and_usertype", unique: true
+    t.index ["email", "usertype", "company_id"], name: "email_usertype_company", unique: true
   end
 
   create_table "companies", force: :cascade do |t|

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -171,6 +171,7 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         And I allow a new email test2@test2.com for usertype company representative
             And that I sign up with the following
@@ -200,6 +201,7 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 1 new email in the database
         And that I sign up with the following
@@ -210,6 +212,7 @@ Feature: Allowlist Management
             | email | test2@test2.com |
             | usertype | company representative |
             | company_id | 2 |
+        And that the user verified their email test2@test2.com
         And that I log in with email test2@test2.com and password password1!
         Then I should see 2 new email in the database
         And I should see an email with index 2 in the database
@@ -233,6 +236,7 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 1 domain in the database
         And that I sign up with the following
@@ -243,6 +247,7 @@ Feature: Allowlist Management
             | email | test2@test2.com |
             | usertype | company representative |
             | company_id | 2 |
+        And that the user verified their email test2@test2.com
         And that I log in with email test2@test2.com and password password1!
         Then I should see 2 domain in the database
         And I should see a domain with index 5 in the database
@@ -264,6 +269,7 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
@@ -275,6 +281,7 @@ Feature: Allowlist Management
             | email | test2@test2.com |
             | usertype | company representative |
             | company_id | 2 |
+        And that the user verified their email test2@test2.com
         And that I log in with email test2@test2.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
@@ -295,6 +302,7 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
@@ -320,8 +328,10 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 2 new email in the database
+        And that the user verified their email test2@test.com
         And that I log in with email test2@test.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
@@ -354,8 +364,10 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 2 new email in the database
+        And that the user verified their email test2@test.com
         And that I log in with email test2@test.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
@@ -388,6 +400,7 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         And I fail to transfer my primary contact role to user with id 3
 
@@ -440,8 +453,10 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 2 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 1 new email in the database
+        And that the user verified their email test2@test.com
         And that I log in with email test2@test.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
@@ -559,6 +574,7 @@ Feature: Allowlist Management
             | password_confirmation | password1! |
             | email | test@test.com |
             | usertype | student |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should not see allowlist emails and domains in company 1 when indexing
         And that I log out

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -82,6 +82,44 @@ Feature: Allowlist Management
         And that I log in as admin
         Then I should see 4 domain in the database
         And the company with id 1 should have 1 reps
+
+    Scenario: An admin allows the same domain for a multiple company
+        Given that I log in as admin
+        And there is a company with id 1
+        And there is a company with id 2
+        And I allow a new domain test.com for usertype student
+        And I allow a new company domain test.com for usertype company representative for company id 1        
+        And I allow a new company domain test.com for usertype company representative for company id 2        
+        Then I should see 6 domain in the database
+
+    Scenario: An admin allows the same domain for a the same company
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company domain test.com for usertype company representative for company id 1        
+        And I fail to allow a new company domain test.com for usertype company representative for company id 1        
+        Then I should see 4 domain in the database
+
+    Scenario: An admin allows the same email for a the same company
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I fail to allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        Then I should see 1 new email in the database
+
+    Scenario: An admin allows the same email for a multiple company
+        Given that I log in as admin
+        And there is a company with id 1
+        And there is a company with id 2
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 2
+        Then I should see 2 new email in the database
+
+    Scenario: An admin allows the same email for a the same company
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I fail to allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        Then I should see 1 new email in the database
         
     Scenario: Log in as admin and create a new email allowed
         Given that I log in as admin

--- a/server/features/signup.feature
+++ b/server/features/signup.feature
@@ -101,6 +101,7 @@ Feature: Student signup
             | email | test@tamu.edu |
             | usertype | student |   
         And that the user verified their email test@tamu.edu
+        And that I log in as admin
         Then the user with firstname james and lastname bond should be found in the user DB
         And the user with firstname jane and lastname bond should NOT be found in the user DB
         And the user with email test@tamu.edu should be marked as verified

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -17,10 +17,22 @@ Given /^I allow a new domain ([^\']*) for usertype ([^\']*)$/ do |domain, userty
   expect(ret.status).to eq(201)
 end
 
+Given /^I fail to allow a new domain ([^\']*) for usertype ([^\']*)$/ do |domain, usertype|
+    ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype}})
+    ret_body = JSON.parse ret.body
+    expect(ret.status).to eq(500)
+  end
+
 Given /^I allow a new company domain ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |domain, usertype, int|
     ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
+end
+
+Given /^I fail to allow a new company domain ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |domain, usertype, int|
+    ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype, "company_id":int}})
+    ret_body = JSON.parse ret.body
+    expect(ret.status).to eq(500)
 end
 
 Given /^I delete the allowed domain with index 4$/ do 
@@ -65,10 +77,22 @@ Given /^I allow a new company email ([^\']*) for usertype ([^\']*) for company i
     expect(ret.status).to eq(201)
 end
 
+Given /^I fail to allow a new company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
+    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int}})
+    ret_body = JSON.parse ret.body
+    expect(ret.status).to eq(500)
+end
+
 Given /^I allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
     ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int, "isPrimaryContact":1}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
+end
+
+Given /^I fail to allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
+    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int, "isPrimaryContact":1}})
+    ret_body = JSON.parse ret.body
+    expect(ret.status).to eq(500)
 end
 
 Given /^I delete the allowed email with index 1$/ do 

--- a/server/features/step_definitions/meeting.rb
+++ b/server/features/step_definitions/meeting.rb
@@ -7,6 +7,9 @@ Given("that I sign up and log in as a valid student") do
   password = SecureRandom.alphanumeric(16)
   email = SecureRandom.alphanumeric(8) + "@tamu.edu"
   page.driver.post("/users", { 'user': { 'firstname': firstname, 'lastname': lastname, 'password': password, 'password_confirmation': password, 'email': email } })
+  user = User.find_by_email(email)
+  user.email_confirmed = true
+  user.save
   ret = page.driver.post("/login", { 'user': { 'password': password, 'email': email } })
   ret_body = JSON.parse ret.body
   expect(ret_body["logged_in"]).to eq(true)

--- a/server/features/step_definitions/signup.rb
+++ b/server/features/step_definitions/signup.rb
@@ -61,6 +61,7 @@ end
 Then /^the user with ([^\'^\ ]*) ([^\'^\ ]*) and ([^\'^\ ]*) ([^\'^\ ]*) should be found in the user DB$/ do |key1, value1, key2, value2|
   ret = page.driver.get("/users/find/?" + key1 + "=" + value1 + "&" + key2 + "=" + value2)
   ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(200)
   expect(ret_body["user"][key1]).to eq(value1)
   expect(ret_body["user"][key2]).to eq(value2)
 end


### PR DESCRIPTION
This should be merged after #51 

Changes:
- Makes it so that the combination of allowlist email/domain + company is unique, rather than just email/domain