### PR TITLE
Add high-level APIs for user-availability association

### DIFF
--- a/server/app/models/availability.rb
+++ b/server/app/models/availability.rb
@@ -14,7 +14,7 @@ class Availability < ApplicationRecord
 
   def associated_meetings(meetings)
     return meetings.where(:start_time => self.start_time..self.end_time)
-             .or(meetings.where(:end_time => self.start_time..self.end_time))
+             .and(meetings.where(:end_time => self.start_time..self.end_time))
   end
 
   private

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -59,15 +59,13 @@ class User < ApplicationRecord
     return owned_meetings - owned_meetings_available_for
   end
 
-  def invited_meetings_available_for
+  def meeting_invitations_available_for
     # NOTE: if we end up with more than 10^4 meetings, this will take a while to return
-    meetings = []
-    availabilities.each { |x| meetings |= x.associated_invited_meetings }
-    return meetings
+    return UserMeeting.where(user: self, meeting: invited_meetings_available_for)
   end
 
-  def invited_meetings_not_available_for
-    return invited_meetings - invited_meetings_available_for
+  def meeting_invitations_not_available_for
+    return UserMeeting.where(user: self, meeting: invited_meetings - invited_meetings_available_for)
   end
 
   private
@@ -76,5 +74,11 @@ class User < ApplicationRecord
     if self.confirm_token.blank?
       self.confirm_token = SecureRandom.urlsafe_base64.to_s
     end
+  end
+
+  def invited_meetings_available_for
+    meetings = []
+    availabilities.each { |x| meetings |= x.associated_invited_meetings }
+    return meetings
   end
 end

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -65,7 +65,8 @@ class User < ApplicationRecord
   end
 
   def meeting_invitations_not_available_for
-    return UserMeeting.where(user: self, meeting: invited_meetings - invited_meetings_available_for)
+    meetings = invited_meetings - invited_meetings_available_for
+    return UserMeeting.where(user: self, meeting: meetings)
   end
 
   private

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -48,6 +48,28 @@ class User < ApplicationRecord
     return UserMeeting.where(status: :declined, user: self).map { |um| um.meeting }
   end
 
+  def owned_meetings_available_for
+    # NOTE: if we end up with more than 10^4 meetings, this will take a while to return
+    meetings = []
+    availabilities.each { |x| meetings |= x.associated_owned_meetings }
+    return meetings
+  end
+
+  def owned_meetings_not_available_for
+    return owned_meetings - owned_meetings_available_for
+  end
+
+  def invited_meetings_available_for
+    # NOTE: if we end up with more than 10^4 meetings, this will take a while to return
+    meetings = []
+    availabilities.each { |x| meetings |= x.associated_invited_meetings }
+    return meetings
+  end
+
+  def invited_meetings_not_available_for
+    return invited_meetings - invited_meetings_available_for
+  end
+
   private
 
   def set_confirm_token

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -48,4 +48,11 @@ Rails.application.routes.draw do
   delete "users/:id/companies/:id", to: "users#delete_from_company"
 
   resources :availabilities, only: [:create, :show, :index, :update, :destroy]
+  get "users/:id/availabilities", to: "users#get_availabilies"
+  get "users/:id/meetings/owned/available", to: "users#get_owned_and_avail_meetings"
+  get "users/:id/meetings/owned/not_available", to: "users#get_owned_but_na_meetings"
+  get "users/:id/user_meetings/available", to: "users#get_invitations_avail"
+  get "users/:id/user_meetings/not_available", to: "users#get_invitations_na"
+  delete "users/:id/meetings/owned/not_available", to: "users#delete_owned_but_na_meetings"
+  delete "users/:id/user_meetings/not_available", to: "users#delete_na_invitations"
 end

--- a/server/features/availability.feature
+++ b/server/features/availability.feature
@@ -116,3 +116,113 @@ Feature: User availability
             | start_time | 2022-11-18 14:00:00 |
             | end_time | 2022-11-18 14:01:00 |
         Then there should be 1 availabilities entries visible to me
+
+    Scenario: Admin request meetings and invitations based on user availabilities 
+        # User 1, admin
+        Given that I log in as admin
+        And I allow a new domain tamu.edu for usertype volunteer
+        # User 2
+        And that an user signs up as a valid volunteer
+        And I want to create an availability with the following and get return status 201
+            | user_id | 2 |
+            | start_time | 2022-10-18 18:00:00 |
+            | end_time | 2022-10-18 19:01:00 |
+        And I want to create an availability with the following and get return status 201
+            | user_id | 2 |
+            | start_time | 2022-10-18 20:20:00 |
+            | end_time | 2022-10-18 20:35:00 |
+        And that I create a meeting with the following
+            | title | Meeting1 |
+            | start_time | '2022-10-18 18:00:00' |
+            | end_time | '2022-10-18 18:30:00' |
+        And that I create a meeting with the following
+            | title | Meeting2 |
+            | start_time | '2022-10-18 18:30:00' |
+            | end_time | '2022-10-18 19:00:00' |
+        And that I create a meeting with the following
+            | title | Meeting3 |
+            | start_time | '2022-10-18 18:40:00' |
+            | end_time | '2022-10-18 19:20:00' |
+        And that I create a meeting with the following
+            | title | Meeting4 |
+            | start_time | '2022-10-18 19:00:00' |
+            | end_time | '2022-10-18 19:05:00' |
+            | owner_id | 2 |
+        And that I create a meeting with the following
+            | title | Meeting5 |
+            | start_time | '2022-10-18 20:20:00' |
+            | end_time | '2022-10-18 20:30:00' |
+            | owner_id | 2 |
+        And that I create a meeting with the following
+            | title | Meeting5 |
+            | start_time | '2022-10-18 20:30:00' |
+            | end_time | '2022-10-18 20:35:00' |
+            | owner_id | 2 |
+        And that I assign user 2 to meeting 1 with status "pending"
+        And that I assign user 2 to meeting 2 with status "accepted"
+        And that I assign user 2 to meeting 3 with status "declined"
+        Then there should be 2 availabilities for user 2
+        And there should be 2 owned and avaliable meetings for user 2
+        And there should be 1 owned but not avaliable meetings for user 2
+        And there should be 2 invitations user 2 is avaliable for
+        And there should be 1 invitations user 2 is not avaliable for
+        
+
+    Scenario: Admin deletes meetinsg and invitations based on user availabilities
+        # User 1, admin
+        Given that I log in as admin
+        And I allow a new domain tamu.edu for usertype volunteer
+        # User 2
+        And that an user signs up as a valid volunteer
+        And I want to create an availability with the following and get return status 201
+            | user_id | 2 |
+            | start_time | 2022-10-18 18:00:00 |
+            | end_time | 2022-10-18 19:01:00 |
+        And I want to create an availability with the following and get return status 201
+            | user_id | 2 |
+            | start_time | 2022-10-18 20:20:00 |
+            | end_time | 2022-10-18 20:35:00 |
+        # Meetings 1~6
+        And that I create a meeting with the following
+            | title | Meeting1 |
+            | start_time | '2022-10-18 18:00:00' |
+            | end_time | '2022-10-18 18:30:00' |
+        And that I create a meeting with the following
+            | title | Meeting2 |
+            | start_time | '2022-10-18 18:30:00' |
+            | end_time | '2022-10-18 19:00:00' |
+        And that I create a meeting with the following
+            | title | Meeting3 |
+            | start_time | '2022-10-18 18:40:00' |
+            | end_time | '2022-10-18 19:20:00' |
+        And that I create a meeting with the following
+            | title | Meeting4 |
+            | start_time | '2022-10-18 19:00:00' |
+            | end_time | '2022-10-18 19:05:00' |
+            | owner_id | 2 |
+        And that I create a meeting with the following
+            | title | Meeting5 |
+            | start_time | '2022-10-18 20:20:00' |
+            | end_time | '2022-10-18 20:30:00' |
+            | owner_id | 2 |
+        And that I create a meeting with the following
+            | title | Meeting5 |
+            | start_time | '2022-10-18 20:30:00' |
+            | end_time | '2022-10-18 20:35:00' |
+            | owner_id | 2 |
+        And that I assign user 2 to meeting 1 with status "pending"
+        And that I assign user 2 to meeting 2 with status "accepted"
+        And that I assign user 2 to meeting 3 with status "declined"
+        Then there should be 2 availabilities for user 2
+        And there should be 2 owned and avaliable meetings for user 2
+        And there should be 1 owned but not avaliable meetings for user 2
+        And there should be 2 invitations user 2 is avaliable for
+        And there should be 1 invitations user 2 is not avaliable for
+        Given that I delete owned but not avaliable meetings for user 2
+        And that I delete invitations user 2 is not avaliable for
+        Then meeting 4 should not exist
+        And user meeting 3 should not exist
+        And there should be 2 owned and avaliable meetings for user 2
+        And there should be 0 owned but not avaliable meetings for user 2
+        And there should be 2 invitations user 2 is avaliable for
+        And there should be 0 invitations user 2 is not avaliable for

--- a/server/features/step_definitions/availability.rb
+++ b/server/features/step_definitions/availability.rb
@@ -47,3 +47,56 @@ Given("I want to update the availability with id {int} with the following and ge
   ret = page.driver.put("/availabilities/#{avail_id}", { "availability": table.rows_hash })
   expect(ret.status).to eq(code)
 end
+
+Then("there should be {int} availabilities for user {int}") do |count, user_id|
+  ret = page.driver.get("/users/#{user_id}/availabilities")
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(200)
+  expect(ret_body["availabilities"].length).to eq(count)
+end
+
+Then("there should be {int} owned and avaliable meetings for user {int}") do |count, user_id|
+  ret = page.driver.get("/users/#{user_id}/meetings/owned/available")
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(200)
+  expect(ret_body["meetings"].length).to eq(count)
+end
+
+Then("there should be {int} owned but not avaliable meetings for user {int}") do |count, user_id|
+  ret = page.driver.get("/users/#{user_id}/meetings/owned/not_available")
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(200)
+  expect(ret_body["meetings"].length).to eq(count)
+end
+
+Then("there should be {int} invitations user {int} is avaliable for") do |count, user_id|
+  ret = page.driver.get("/users/#{user_id}/user_meetings/available")
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(200)
+  expect(ret_body["user_meetings"].length).to eq(count)
+end
+
+Then("there should be {int} invitations user {int} is not avaliable for") do |count, user_id|
+  ret = page.driver.get("/users/#{user_id}/user_meetings/not_available")
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(200)
+  expect(ret_body["user_meetings"].length).to eq(count)
+end
+
+Given("that I delete owned but not avaliable meetings for user {int}") do |id|
+  ret = page.driver.delete("/users/#{id}/meetings/owned/not_available")
+  expect(ret.status).to eq(200)
+end
+
+Given("that I delete invitations user {int} is not avaliable for") do |id|
+  ret = page.driver.delete("/users/#{id}/user_meetings/not_available")
+  expect(ret.status).to eq(200)
+end
+
+Then("meeting {int} should not exist") do |id|
+  expect(Meeting.find_by_id(id)).to eq(nil)
+end
+
+Then("user meeting {int} should not exist") do |id|
+  expect(UserMeeting.find_by_id(id)).to eq(nil)
+end

--- a/server/features/step_definitions/signup.rb
+++ b/server/features/step_definitions/signup.rb
@@ -20,23 +20,32 @@ Given("that an user signs up as a valid student") do
   expect(ret.status).to eq(201)
 end
 
-Given('I delete my account') do
-  ret = page.driver.delete('/users/')
+Given("that an user signs up as a valid volunteer") do
+  firstname = SecureRandom.alphanumeric(8)
+  lastname = SecureRandom.alphanumeric(8)
+  password = SecureRandom.alphanumeric(16)
+  email = SecureRandom.alphanumeric(8) + "@tamu.edu"
+  ret = page.driver.post("/users", { 'user': { 'firstname': firstname, 'lastname': lastname, 'password': password, 'password_confirmation': password, 'email': email, 'usertype': "volunteer" } })
+  expect(ret.status).to eq(201)
+end
+
+Given("I delete my account") do
+  ret = page.driver.delete("/users/")
   expect(ret.status).to eq(200)
 end
 
-Given('I delete the account for id {int}') do |int|
-  ret = page.driver.delete('/users/'+int.to_s)
+Given("I delete the account for id {int}") do |int|
+  ret = page.driver.delete("/users/" + int.to_s)
   expect(ret.status).to eq(200)
 end
 
-Given('I fail to delete the account for id {int}') do |int|
-  ret = page.driver.delete('/users/'+int.to_s)
+Given("I fail to delete the account for id {int}") do |int|
+  ret = page.driver.delete("/users/" + int.to_s)
   expect(ret.status).to eq(403)
 end
 
 Given /^that I update my password to ([^\']*)$/ do |pw|
-  ret = page.driver.put("/users/password", { 'user': {'password': pw, 'password_confirmation': pw} })
+  ret = page.driver.put("/users/password", { 'user': { 'password': pw, 'password_confirmation': pw } })
   expect(ret.status).to eq(200)
 end
 

--- a/server/spec/models/availability_spec.rb
+++ b/server/spec/models/availability_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Availability, type: :model do
     Meeting.create(owner_id: 1, title: "meeting2", start_time: "2022-10-18 14:50:00", end_time: "2022-10-18 14:51:00")
 
     Availability.create(user_id: 2, start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:40:00")
-    Availability.create(user_id: 2, start_time: "2022-10-18 14:50:30", end_time: "2022-10-18 14:51:00")
+    Availability.create(user_id: 2, start_time: "2022-10-18 14:50:00", end_time: "2022-10-18 14:51:00")
 
     UserMeeting.create(meeting_id: 1, user_id: 2, status: :accepted)
     UserMeeting.create(meeting_id: 2, user_id: 2, status: :pending)
     UserMeeting.create(meeting_id: 3, user_id: 2, status: :pending)
 
-    expect(Availability.find(1).associated_invited_meetings).to match_array([Meeting.find(1), Meeting.find(2)])
+    expect(Availability.find(1).associated_invited_meetings).to match_array([Meeting.find(1)])
     expect(Availability.find(2).associated_invited_meetings).to match_array([Meeting.find(3)])
     expect(Availability.find(1).associated_owned_meetings).to match_array([])
     expect(Availability.find(2).associated_owned_meetings).to match_array([])
@@ -43,9 +43,9 @@ RSpec.describe Availability, type: :model do
     Meeting.find(2).update_attribute(:owner_id, 2)
     Meeting.find(3).update_attribute(:owner_id, 2)
 
-    expect(Availability.find(1).associated_invited_meetings).to match_array([Meeting.find(1), Meeting.find(2)])
+    expect(Availability.find(1).associated_invited_meetings).to match_array([Meeting.find(1)])
     expect(Availability.find(2).associated_invited_meetings).to match_array([Meeting.find(3)])
-    expect(Availability.find(1).associated_owned_meetings).to match_array([Meeting.find(1), Meeting.find(2)])
+    expect(Availability.find(1).associated_owned_meetings).to match_array([Meeting.find(1)])
     expect(Availability.find(2).associated_owned_meetings).to match_array([Meeting.find(3)])
   end
 end

--- a/server/spec/models/user_spec.rb
+++ b/server/spec/models/user_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe User, type: :model do
     UserMeeting.create(meeting_id: 3, user_id: 2, status: :pending)
     UserMeeting.create(meeting_id: 4, user_id: 2, status: :pending)
 
-    expect(User.find(2).invited_meetings_available_for).to match_array([Meeting.find(1), Meeting.find(2), Meeting.find(3)])
-    expect(User.find(2).invited_meetings_not_available_for).to match_array([Meeting.find(4)])
+    expect(User.find(2).meeting_invitations_available_for).to match_array([UserMeeting.find(1), UserMeeting.find(2), UserMeeting.find(3)])
+    expect(User.find(2).meeting_invitations_not_available_for).to match_array([UserMeeting.find(4)])
   end
 end

--- a/server/spec/models/user_spec.rb
+++ b/server/spec/models/user_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe User, type: :model do
     Meeting.find(2).update_attribute(:owner_id, 2)
     Meeting.find(3).update_attribute(:owner_id, 2)
 
-    expect(User.find(2).owned_meetings_available_for).to match_array([Meeting.find(1), Meeting.find(2), Meeting.find(3)])
-    expect(User.find(2).owned_meetings_not_available_for).to match_array([Meeting.find(4)])
+    expect(User.find(2).owned_meetings_available_for).to match_array([Meeting.find(1)])
+    expect(User.find(2).owned_meetings_not_available_for).to match_array([Meeting.find(2), Meeting.find(3), Meeting.find(4)])
   end
 
   it "should filter invited meetings correctly based on availability" do
@@ -68,7 +68,7 @@ RSpec.describe User, type: :model do
     UserMeeting.create(meeting_id: 3, user_id: 2, status: :pending)
     UserMeeting.create(meeting_id: 4, user_id: 2, status: :pending)
 
-    expect(User.find(2).meeting_invitations_available_for).to match_array([UserMeeting.find(1), UserMeeting.find(2), UserMeeting.find(3)])
-    expect(User.find(2).meeting_invitations_not_available_for).to match_array([UserMeeting.find(4)])
+    expect(User.find(2).meeting_invitations_available_for).to match_array([UserMeeting.find(1)])
+    expect(User.find(2).meeting_invitations_not_available_for).to match_array([UserMeeting.find(2), UserMeeting.find(3), UserMeeting.find(4)])
   end
 end

--- a/server/spec/models/user_spec.rb
+++ b/server/spec/models/user_spec.rb
@@ -32,4 +32,43 @@ RSpec.describe User, type: :model do
     user = User.create(firstname: "John", lastname: "Doe", email: "hello@hello.com", password: "something")
     expect(user.confirm_token).to_not be(nil)
   end
+
+  it "should filter owned meetings correctly based on availability" do
+    User.create(firstname: "user2", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "volunteer")
+
+    Meeting.create(owner_id: 2, title: "meeting1", start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:20:00")
+    Meeting.create(owner_id: 2, title: "meeting2", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00")
+    Meeting.create(owner_id: 2, title: "meeting3", start_time: "2022-10-18 14:50:00", end_time: "2022-10-18 14:51:00")
+    Meeting.create(owner_id: 2, title: "meeting4", start_time: "2022-10-19 14:50:00", end_time: "2022-10-19 14:51:00")
+
+    Availability.create(user_id: 2, start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:40:00")
+    Availability.create(user_id: 2, start_time: "2022-10-18 14:50:30", end_time: "2022-10-18 14:51:00")
+
+    Meeting.find(1).update_attribute(:owner_id, 2)
+    Meeting.find(2).update_attribute(:owner_id, 2)
+    Meeting.find(3).update_attribute(:owner_id, 2)
+
+    expect(User.find(2).owned_meetings_available_for).to match_array([Meeting.find(1), Meeting.find(2), Meeting.find(3)])
+    expect(User.find(2).owned_meetings_not_available_for).to match_array([Meeting.find(4)])
+  end
+
+  it "should filter invited meetings correctly based on availability" do
+    User.create(firstname: "user2", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "volunteer")
+
+    Meeting.create(owner_id: 1, title: "meeting1", start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:20:00")
+    Meeting.create(owner_id: 1, title: "meeting2", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00")
+    Meeting.create(owner_id: 1, title: "meeting3", start_time: "2022-10-18 14:50:00", end_time: "2022-10-18 14:51:00")
+    Meeting.create(owner_id: 1, title: "meeting4", start_time: "2022-10-19 14:50:00", end_time: "2022-10-19 14:51:00")
+
+    Availability.create(user_id: 2, start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:40:00")
+    Availability.create(user_id: 2, start_time: "2022-10-18 14:50:30", end_time: "2022-10-18 14:51:00")
+
+    UserMeeting.create(meeting_id: 1, user_id: 2, status: :accepted)
+    UserMeeting.create(meeting_id: 2, user_id: 2, status: :pending)
+    UserMeeting.create(meeting_id: 3, user_id: 2, status: :pending)
+    UserMeeting.create(meeting_id: 4, user_id: 2, status: :pending)
+
+    expect(User.find(2).invited_meetings_available_for).to match_array([Meeting.find(1), Meeting.find(2), Meeting.find(3)])
+    expect(User.find(2).invited_meetings_not_available_for).to match_array([Meeting.find(4)])
+  end
 end


### PR DESCRIPTION
- Add API that can perform actions on user meetings or meetings based on the overlap with user availability
- APIs added (doc to be updated)
  - GET    /users/:id/availabilities
    - Get all of user's availabilties
  - GET    /users/:id/meetings/owned/available
    - Get meetings owned by user that the user's available for
  - GET    /users/:id/meetings/owned/not_available
     - Get meetings owned by user that the user's NOT available for
  - GET    /users/:id/user_meetings/available
    - Get a user's user_meetings (invitations) that the user's available for
  - GET    /users/:id/user_meetings/not_available
    - Get a user's user_meetings (invitations) that the user's NOT available for
  - DELETE /users/:id/meetings/owned/not_available
    - Delete all meeting that the user's not available for
  - DELETE /users/:id/user_meetings/not_available
    - Delete all user_meetings (invitaitions) that the user's not available for