### PR TITLE
Add batch update for meeting invitees

### DIFF
--- a/server/app/controllers/meetings_controller.rb
+++ b/server/app/controllers/meetings_controller.rb
@@ -143,9 +143,15 @@ class MeetingsController < ApplicationController
     if !confirm_requester_is_owner_or_admin(@meeting.owner.id)
       return
     end
-
+    invitees = nil
+    if params.key?("status")
+      # e.g. /meetings/1/invites/?status=accepted
+      invitees = @meeting.invites_by_status(params["status"])
+    else
+      invitees = @meeting.invitees
+    end
     render json: {
-      invitees: @meeting.invitees,
+      invitees: invitees,
     }
   end
 

--- a/server/app/models/meeting.rb
+++ b/server/app/models/meeting.rb
@@ -23,4 +23,14 @@ class Meeting < ApplicationRecord
     end
     return ret
   end
+
+  def invites_by_status(status)
+    ret = []
+    for user_meeting in user_meetings
+      if user_meeting.status == status
+        ret.push(user_meeting.user)
+      end
+    end
+    return ret
+  end
 end

--- a/server/app/models/user_meeting.rb
+++ b/server/app/models/user_meeting.rb
@@ -4,8 +4,10 @@ class UserMeeting < ApplicationRecord
   before_create :owner_not_invitee
   before_create :duplicate_invitee
   validates :status,
-            :inclusion => { :in => ["pending", "accepted", "cancelled", "declined"],
+            :inclusion => { :in => :valid_status,
                             :message => "%{value} is not a valid status" }
+
+  class_attribute :valid_status, default: ["pending", "accepted", "cancelled", "declined"]
 
   def owner_not_invitee
     if self.meeting.owner == self.user

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
   delete "/users/:id/meetings/:meeting_id", to: "users#delete_from_meeting"
 
   resources :meetings, only: [:create, :show, :index, :update, :destroy]
+  get "meetings/:id/invitees", to: "meetings#get_invitees"
+  put "meetings/:id/invitees", to: "meetings#swap_invitees"
   resources :user_meetings, only: [:show, :index]
 
   get "/companies", to: "companies#index"
@@ -48,7 +50,7 @@ Rails.application.routes.draw do
   delete "/companies/:id", to: "companies#destroy"
   # post "/users/:id/companies/:company_id", to: "users#add_to_company"
   # delete "users/:id/companies/:company_id", to: "users#delete_from_company"
-  get "/companies/public", to: "companies#public_index", as: 'public_index'
+  get "/companies/public", to: "companies#public_index", as: "public_index"
 
   resources :availabilities, only: [:create, :show, :index, :update, :destroy]
   get "users/:id/availabilities", to: "users#get_availabilies"

--- a/server/features/meeting.feature
+++ b/server/features/meeting.feature
@@ -156,3 +156,28 @@ Feature: Meeting
             | 5 | declined |
         Then meeting 1 should have as invitees the following users
             | 3 | 5 |
+    
+    Scenario: Mass update invitees
+        # User 2-6
+        Given a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And that I log in as admin
+        And that I create a valid meeting
+        Then I get code 200 when mass updating meeting 1's invitees with
+            | user_id | status |
+            | 2 | pending |
+            | 3 | accepted |
+            | 4 | cancelled |
+            | 5 | declined |
+            | 6 | accepted |
+        Then meeting 1 should have as "pending" invitees the following users
+            | 2 |
+        Then meeting 1 should have as "accepted" invitees the following users
+            | 3 | 6 |
+        Then meeting 1 should have as "cancelled" invitees the following users
+            | 4 |
+        Then meeting 1 should have as "declined" invitees the following users
+            | 5 |

--- a/server/features/meeting.feature
+++ b/server/features/meeting.feature
@@ -113,3 +113,46 @@ Feature: Meeting
             | end_time | '2022-10-18 18:20:00' |
         And that I log in as admin
         Then 0 meetings should be in meeting DB
+
+    Scenario: Mass update invitees
+        # User 2-6
+        Given a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And a student signs up and confirms their email
+        And that I log in as admin
+        And that I create a valid meeting
+        Then I get code 200 when mass updating meeting 1's invitees with
+            | user_id | status |
+            | 2 | pending |
+            | 3 | accepted |
+            | 4 | cancelled |
+            | 5 | declined |
+        Then meeting 1 should have as invitees the following users
+            | 2 | 3 | 4 | 5 |
+        # Pass invalid status
+        Then I get code 400 when mass updating meeting 1's invitees with
+            | user_id | status |
+            | 2 | invalid |
+        # Above failed mass update shouldn't have affected the invitees
+        Then meeting 1 should have as invitees the following users
+            | 2 | 3 | 4 | 5 |
+        # Pass invalid user
+        Then I get code 400 when mass updating meeting 1's invitees with
+            | user_id | status |
+            | 7 | pending |
+        # Above failed mass update shouldn't have affected the invitees
+        Then meeting 1 should have as invitees the following users
+            | 2 | 3 | 4 | 5 |
+        Then I get code 200 when mass updating meeting 1's invitees with
+            | user_id | status |
+            | 2 | pending |
+            | 4 | cancelled |
+        Then meeting 1 should have as invitees the following users
+            | 2 | 4 |
+        Then I get code 200 when mass updating meeting 1's invitees with
+            | user_id | status |
+            | 3 | accepted |
+            | 5 | declined |
+        Then meeting 1 should have as invitees the following users
+            | 3 | 5 |

--- a/server/features/step_definitions/meeting.rb
+++ b/server/features/step_definitions/meeting.rb
@@ -110,5 +110,13 @@ Then("meeting {int} should have as invitees the following users") do |id, invite
   ret_body = JSON.parse ret.body
   invitees_actual = []
   ret_body["invitees"].each { |h| invitees_actual << h["id"].to_s }
-  expect(invitees_actual).to eq(p invitees.raw[0].each { |id| id.to_i })
+  expect(invitees_actual).to eq(invitees.raw[0].each { |id| id.to_i })
+end
+
+Then("meeting {int} should have as {string} invitees the following users") do |id, status, invitees|
+  ret = page.driver.get("/meetings/#{id}/invitees?status=#{status}")
+  ret_body = JSON.parse ret.body
+  invitees_actual = []
+  ret_body["invitees"].each { |h| invitees_actual << h["id"].to_s }
+  expect(invitees_actual).to eq(invitees.raw[0].each { |id| id.to_i })
 end

--- a/server/features/step_definitions/meeting.rb
+++ b/server/features/step_definitions/meeting.rb
@@ -15,16 +15,16 @@ Given("that I sign up and log in as a valid student") do
   expect(ret_body["logged_in"]).to eq(true)
 end
 
-# Given("that I sign up and log in as a valid admin") do
-#   firstname = SecureRandom.alphanumeric(8)
-#   lastname = SecureRandom.alphanumeric(8)
-#   password = SecureRandom.alphanumeric(16)
-#   email = SecureRandom.alphanumeric(8) + "@" + SecureRandom.alphanumeric(8) + "." + SecureRandom.alphanumeric(3)
-#   page.driver.post("/users", { 'user': { 'firstname': firstname, 'lastname': lastname, 'password': password, 'password_confirmation': password, 'email': email, 'usertype': "admin" } })
-#   ret = page.driver.post("/login", { 'user': { 'password': password, 'email': email } })
-#   ret_body = JSON.parse ret.body
-#   expect(ret_body["logged_in"]).to eq(true)
-# end
+Given("a student signs up and confirms their email") do
+  firstname = SecureRandom.alphanumeric(8)
+  lastname = SecureRandom.alphanumeric(8)
+  password = SecureRandom.alphanumeric(16)
+  email = SecureRandom.alphanumeric(8) + "@tamu.edu"
+  page.driver.post("/users", { 'user': { 'firstname': firstname, 'lastname': lastname, 'password': password, 'password_confirmation': password, 'email': email } })
+  user = User.find_by_email(email)
+  user.email_confirmed = true
+  user.save
+end
 
 Given("that I create a valid meeting") do
   title = SecureRandom.alphanumeric(8)
@@ -97,6 +97,18 @@ end
 
 Then("deleting the meeting with id {int} should succeed") do |id|
   ret = page.driver.delete("/meetings/" + id.to_s)
-  ret_body = JSON.parse ret.body
   expect(ret.status).to eq(200)
+end
+
+Then("I get code {int} when mass updating meeting {int}'s invitees with") do |status, id, table|
+  ret = page.driver.put("/meetings/#{id}/invitees", { 'meeting': { 'invitees': table.hashes } })
+  expect(ret.status).to eq(status)
+end
+
+Then("meeting {int} should have as invitees the following users") do |id, invitees|
+  ret = page.driver.get("/meetings/#{id}/invitees")
+  ret_body = JSON.parse ret.body
+  invitees_actual = []
+  ret_body["invitees"].each { |h| invitees_actual << h["id"].to_s }
+  expect(invitees_actual).to eq(p invitees.raw[0].each { |id| id.to_i })
 end


### PR DESCRIPTION
- Add routes `GET meetings/id/invitees`, `PUT meetings/id/invitees`
- `PUT meetings/id/invitees`
  - Execution steps
    - 1. Check meeting existence and user permission
    - 2. Validates provided parameters
    - 3. Deletes previous user-meeting associations
    - 4. Creates new user-meeting associations with 
      - Any error from step 3 and on is potentially destructive. Refrain from using this whenever you can get away without this.
  - Example payload:
    - ```json
      {
          "meeting": {
              "invitees": [
                  {
                      "user_id": 1,
                      "status": "accepted"
                  },
                  {
                      "user_id": 5,
                      "status": "declined"
                  },
                  {
                      "user_id": 3,
                      "status": "pending"
                  }
              ]
          }
      }
      ```
- `GET meetings/id/invitees`
  - Default GET request: returns all invitees of a meeting
  - GET invitees of filtered by invite status
    - `GET meetings/1/invitees/?status=accepted`