### PR TITLE
Add events model

### DIFF
--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -1,6 +1,6 @@
 class AllowlistDomainsController < ApplicationController
   before_action :confirm_user_logged_in
-  before_action :confirm_requester_is_rep_or_admin, only: [:create, :delete, :index, :show]
+  before_action :confirm_requester_is_rep_or_admin, only: [:create, :destroy, :index, :show]
 
   def index
     @domains = AllowlistDomain.all

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -1,6 +1,6 @@
 class AllowlistEmailsController < ApplicationController
   before_action :confirm_user_logged_in
-  before_action :confirm_requester_is_rep_or_admin, only: [:create, :delete, :index, :show, :transferPrimaryContact]
+  before_action :confirm_requester_is_rep_or_admin, only: [:create, :destroy, :index, :show, :transferPrimaryContact]
 
   def index
     @emails = AllowlistEmail.all

--- a/server/app/controllers/availabilities_controller.rb
+++ b/server/app/controllers/availabilities_controller.rb
@@ -1,6 +1,6 @@
 class AvailabilitiesController < ApplicationController
   before_action :confirm_user_logged_in
-  before_action :confirm_availability_exists, only: [:show, :update, :delete]
+  before_action :confirm_availability_exists, only: [:show, :update, :destroy]
 
   def confirm_event_exists(event_id)
     if !Event.find_by_id(event_id)

--- a/server/app/controllers/events_controller.rb
+++ b/server/app/controllers/events_controller.rb
@@ -182,26 +182,6 @@ class EventsController < ApplicationController
     end
   end
 
-  def confirm_meeting_exists(id)
-    if !Meeting.find_by_id(id)
-      render json: {
-               errors: ["Meeting with id #{id} not found"],
-             }, status: :not_found
-      return false
-    end
-    return true
-  end
-
-  def confirm_availability_exists(id)
-    if !Availability.find_by_id(id)
-      render json: {
-               errors: ["Availability with id #{id} not found"],
-             }, status: :not_found
-      return false
-    end
-    return true
-  end
-
   def confirm_requester_is_admin
     if current_user.usertype != "admin"
       render json: {

--- a/server/app/controllers/events_controller.rb
+++ b/server/app/controllers/events_controller.rb
@@ -1,0 +1,125 @@
+class EventsController < ApplicationController
+  before_action :confirm_user_logged_in, except: [:index, :show]
+  before_action :confirm_event_exists, only: [:show, :update, :destroy]
+
+  # GET /events
+  def index
+    render json: {
+             events: Event.all,
+           }, status: :ok
+  end
+
+  # GET /events/1
+  def show
+    @event = Event.find(params[:id])
+    render json: {
+             event: @event,
+           }, status: :ok
+  end
+
+  # POST /events/
+  def create
+    if !confirm_requester_is_admin
+      return
+    end
+    params = event_params.to_h
+
+    @event = Event.new(params)
+    if @event.save
+      render json: {
+               event: @event,
+             }, status: :created
+    else
+      render json: {
+               errors: @event.errors.full_messages,
+             }, status: :internal_server_error
+    end
+  end
+
+  # PUT /events/1/
+  def update
+    @event = Event.find(params[:id])
+    if !confirm_requester_is_admin
+      return
+    end
+
+    if @event.update(event_params)
+      render json: {
+               event: @event,
+             }, status: :ok
+    else
+      render json: {
+               errors: @event.errors.full_messages,
+             }, status: :internal_server_error
+    end
+  end
+
+  # DELETE /events/1/
+  def destroy
+    @event = Event.find(params[:id])
+    if !confirm_requester_is_admin
+      return
+    end
+    if @event.destroy
+      render json: {
+               event: @event,
+             }, status: :ok
+    else
+      render json: {
+               errors: @event.errors.full_messages,
+             }, status: :internal_server_error
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:title, :description, :start_time, :end_time)
+  end
+
+  def confirm_user_logged_in
+    if !(logged_in? && current_user)
+      render json: {
+               errors: ["User not logged in"],
+             }, status: :unauthorized
+    end
+  end
+
+  def confirm_event_exists
+    if !Event.find_by_id(params[:id])
+      render json: {
+               errors: ["Event with id #{params[:id]} not found"],
+             }, status: :not_found
+    end
+  end
+
+  def confirm_meeting_exists(id)
+    if !Meeting.find_by_id(id)
+      render json: {
+               errors: ["Meeting with id #{id} not found"],
+             }, status: :not_found
+      return false
+    end
+    return true
+  end
+
+  def confirm_availability_exists(id)
+    if !Availability.find_by_id(id)
+      render json: {
+               errors: ["Availability with id #{id} not found"],
+             }, status: :not_found
+      return false
+    end
+    return true
+  end
+
+  def confirm_requester_is_admin
+    if current_user.usertype != "admin"
+      render json: {
+               errors: ["User does not have previleges for requested action"],
+             }, status: :forbidden
+      return false
+    end
+    return true
+  end
+end

--- a/server/app/controllers/meetings_controller.rb
+++ b/server/app/controllers/meetings_controller.rb
@@ -1,6 +1,6 @@
 class MeetingsController < ApplicationController
   before_action :confirm_user_logged_in
-  before_action :confirm_meeting_exists, only: [:show, :update, :delete]
+  before_action :confirm_meeting_exists, only: [:show, :update, :destroy]
 
   def confirm_user_logged_in
     if !(logged_in? && current_user)

--- a/server/app/controllers/user_meetings_controller.rb
+++ b/server/app/controllers/user_meetings_controller.rb
@@ -9,16 +9,6 @@ class UserMeetingsController < ApplicationController
     end
   end
 
-  def confirm_requester_is_admin
-    if current_user.usertype != "admin"
-      render json: {
-               errors: ["User does not have previleges for requested action"],
-             }, status: :forbidden
-      return false
-    end
-    return true
-  end
-
   def index
     render json: {
              user_meetings: UserMeeting.all,

--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :confirm_user_logged_in, except: [:new, :create, :confirm_email]
-  before_action :confirm_user_exists, only: [:show, :assigned_to_meeting?, :get_meetings, :get_accepted_meetings, :get_pending_meetings, :get_owned_meetings, :add_to_meeting, :update_meeting, :delete]
+  before_action :confirm_user_exists, only: [:show, :assigned_to_meeting?, :get_meetings, :get_accepted_meetings, :get_pending_meetings, :get_owned_meetings, :add_to_meeting, :update_meeting]
   before_action :confirm_meeting_exists, only: [:assigned_to_meeting?, :add_to_meeting, :update_meeting, :delete_from_meeting]
 
   def confirm_user_logged_in

--- a/server/app/models/availability.rb
+++ b/server/app/models/availability.rb
@@ -1,5 +1,6 @@
 class Availability < ApplicationRecord
   belongs_to :user
+  belongs_to :event, optional: true
   validates :user, presence: true
   validate :is_user_corporate_or_volunteer?, if: :user
   validates :start_time, comparison: { less_than: :end_time }

--- a/server/app/models/event.rb
+++ b/server/app/models/event.rb
@@ -1,0 +1,5 @@
+class Event < ApplicationRecord
+  has_many :event_signups
+  has_many :users, through: :event_signups, source: :user
+  validates :start_time, comparison: { less_than: :end_time }
+end

--- a/server/app/models/event.rb
+++ b/server/app/models/event.rb
@@ -1,5 +1,7 @@
 class Event < ApplicationRecord
   has_many :event_signups
   has_many :users, through: :event_signups, source: :user
+  has_many :meetings
+  has_many :availabilities
   validates :start_time, comparison: { less_than: :end_time }
 end

--- a/server/app/models/event_signup.rb
+++ b/server/app/models/event_signup.rb
@@ -1,0 +1,4 @@
+class EventSignup < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/server/app/models/meeting.rb
+++ b/server/app/models/meeting.rb
@@ -1,5 +1,6 @@
 class Meeting < ApplicationRecord
   belongs_to :owner, class_name: "User"
+  belongs_to :event, class_name: "Event", optional: true
   has_many :user_meetings, dependent: :destroy
   has_many :invitees, through: :user_meetings, source: :user
   validates :start_time, comparison: { less_than: :end_time }

--- a/server/app/models/user.rb
+++ b/server/app/models/user.rb
@@ -16,7 +16,11 @@ class User < ApplicationRecord
   has_many :owned_meetings, foreign_key: :owner, class_name: "Meeting", dependent: :destroy
   has_many :user_meetings, dependent: :destroy
   has_many :invited_meetings, through: :user_meetings, source: :meeting
+
   has_many :availabilities, dependent: :destroy
+
+  has_many :event_signups, dependent: :destroy
+  has_many :events, through: :event_signups, source: :event
 
   belongs_to :allowlist_domain, optional: true
   belongs_to :allowlist_email, optional: true

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
   delete "/companies/:id", to: "companies#destroy"
   # post "/users/:id/companies/:company_id", to: "users#add_to_company"
   # delete "users/:id/companies/:company_id", to: "users#delete_from_company"
-  get "/companies/public", to: "companies#public_index", as: 'public_index'
+  get "/companies/public", to: "companies#public_index", as: "public_index"
 
   resources :availabilities, only: [:create, :show, :index, :update, :destroy]
   get "users/:id/availabilities", to: "users#get_availabilies"
@@ -58,4 +58,6 @@ Rails.application.routes.draw do
   get "users/:id/user_meetings/not_available", to: "users#get_invitations_na"
   delete "users/:id/meetings/owned/not_available", to: "users#delete_owned_but_na_meetings"
   delete "users/:id/user_meetings/not_available", to: "users#delete_na_invitations"
+
+  resources :events, only: [:index, :create, :show, :update, :destroy]
 end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -60,4 +60,10 @@ Rails.application.routes.draw do
   delete "users/:id/user_meetings/not_available", to: "users#delete_na_invitations"
 
   resources :events, only: [:index, :create, :show, :update, :destroy]
+  get "events/:id/availabilities", to: "events#get_availabilities"
+  get "events/:id/meetings", to: "events#get_meetings"
+  get "events/:id/users", to: "events#get_users"
+
+  post "events/:id/users/:user_id", to: "events#signup"
+  delete "events/:id/users/:user_id", to: "events#signout"
 end

--- a/server/db/migrate/20221128182049_create_events.rb
+++ b/server/db/migrate/20221128182049_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :events do |t|
+      t.timestamp :start_time
+      t.timestamp :end_time
+
+      t.timestamps
+    end
+  end
+end

--- a/server/db/migrate/20221128182133_create_event_signups.rb
+++ b/server/db/migrate/20221128182133_create_event_signups.rb
@@ -1,0 +1,10 @@
+class CreateEventSignups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :event_signups do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/server/db/migrate/20221128183353_add_title_and_description_to_event.rb
+++ b/server/db/migrate/20221128183353_add_title_and_description_to_event.rb
@@ -1,0 +1,6 @@
+class AddTitleAndDescriptionToEvent < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :title, :string
+    add_column :events, :description, :text
+  end
+end

--- a/server/db/migrate/20221128185406_add_event_fk_to_meetings.rb
+++ b/server/db/migrate/20221128185406_add_event_fk_to_meetings.rb
@@ -1,0 +1,5 @@
+class AddEventFkToMeetings < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :meetings, :event, foreign_key: true
+  end
+end

--- a/server/db/migrate/20221128185617_add_event_fk_to_availability.rb
+++ b/server/db/migrate/20221128185617_add_event_fk_to_availability.rb
@@ -1,0 +1,5 @@
+class AddEventFkToAvailability < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :availabilities, :event, foreign_key: true
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_18_021729) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_183353) do
   create_table "allowlist_domains", force: :cascade do |t|
     t.string "email_domain"
     t.string "usertype"
@@ -46,9 +46,27 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_021729) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "event_signups", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_event_signups_on_event_id"
+    t.index ["user_id"], name: "index_event_signups_on_user_id"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.datetime "start_time", precision: nil
+    t.datetime "end_time", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.text "description"
+  end
+
   create_table "faqs", force: :cascade do |t|
-    t.string "question", null: false
-    t.text "answer", null: false
+    t.string "question"
+    t.text "answer"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -68,7 +86,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_021729) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status", default: "pending"
+    t.string "status"
     t.index ["meeting_id"], name: "index_user_meetings_on_meeting_id"
     t.index ["user_id"], name: "index_user_meetings_on_user_id"
   end
@@ -96,6 +114,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_021729) do
   add_foreign_key "allowlist_domains", "companies"
   add_foreign_key "allowlist_emails", "companies"
   add_foreign_key "availabilities", "users"
+  add_foreign_key "event_signups", "events"
+  add_foreign_key "event_signups", "users"
   add_foreign_key "meetings", "users", column: "owner_id"
   add_foreign_key "user_meetings", "meetings"
   add_foreign_key "user_meetings", "users"

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_183353) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_185617) do
   create_table "allowlist_domains", force: :cascade do |t|
     t.string "email_domain"
     t.string "usertype"
@@ -36,6 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_183353) do
     t.datetime "end_time", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "event_id"
+    t.index ["event_id"], name: "index_availabilities_on_event_id"
     t.index ["user_id"], name: "index_availabilities_on_user_id"
   end
 
@@ -78,6 +80,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_183353) do
     t.integer "owner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "event_id"
+    t.index ["event_id"], name: "index_meetings_on_event_id"
     t.index ["owner_id"], name: "index_meetings_on_owner_id"
   end
 
@@ -113,9 +117,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_183353) do
 
   add_foreign_key "allowlist_domains", "companies"
   add_foreign_key "allowlist_emails", "companies"
+  add_foreign_key "availabilities", "events"
   add_foreign_key "availabilities", "users"
   add_foreign_key "event_signups", "events"
   add_foreign_key "event_signups", "users"
+  add_foreign_key "meetings", "events"
   add_foreign_key "meetings", "users", column: "owner_id"
   add_foreign_key "user_meetings", "meetings"
   add_foreign_key "user_meetings", "users"

--- a/server/features/availability.feature
+++ b/server/features/availability.feature
@@ -344,3 +344,40 @@ Feature: User availability
             | end_time | 2022-11-19 14:01:00 |
         And I should see 3 availabilities for user with id 2 for company with id 1
         And I should see 2 availabilities for user with id 3 for company with id 1
+
+    Scenario: Create availabilities with ghost event
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype volunteer
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | volunteer |
+        And that I log in as admin
+        Then creating an availability with the following should return status 404
+            | user_id | 2 |
+            | start_time | 2022-11-18 14:00:00 |
+            | end_time | 2022-11-18 14:01:00 |
+            | event_id | 100 |
+    
+    Scenario: Assign user availability to a ghost event
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that the user verified their email test@test.com
+        And that I log in with email test@test.com and password password1!
+        And I want to create an availability with the following and get return status 201
+            | start_time | 2022-11-18 14:00:00 |
+            | end_time | 2022-11-18 14:01:00 |
+        Then updating an availability 1 with the following should return status 404
+            | event_id | 100 |

--- a/server/features/event.feature
+++ b/server/features/event.feature
@@ -1,0 +1,84 @@
+Feature: Event
+    In order to group meetings and availabilities
+    And see the interested users
+    As an admin
+    I want to add events
+
+
+    Scenario: Create event as admin
+        Given that I log in as admin
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+    
+    Scenario: Create event as admin with bad time
+        Given that I log in as admin
+        Then creating an event with the following should return code 500
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 17:20:00' |
+    
+    Scenario: Access events as user
+        Given that I log in as admin
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+        And creating an event with the following should return code 201
+            | title | Another event |
+            | description | Something |
+            | start_time | '2022-10-19 18:10:00' |
+            | end_time | '2022-10-19 18:20:00' |
+        Given that I log out
+        Then there should be 2 events in the DB
+        Then event 1 should have title "Mock interview"
+    
+    Scenario: Update event as admin
+        Given that I log in as admin
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+        Then I request update event 1 with the following and recieve code 200
+            | title | Mock interview (2)|
+        Then event 1 should have title "Mock interview (2)"
+    
+    Scenario: Delete event as admin
+        Given that I log in as admin
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+        And I request delete event 1 and recieve code 200
+        And creating an event with the following should return code 201
+            | title | Another event |
+            | description | Something |
+            | start_time | '2022-10-19 18:10:00' |
+            | end_time | '2022-10-19 18:20:00' |
+        Then there should be 1 events in the DB
+    
+    Scenario: Create, update, delete event as user
+        Given that I log in as admin
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+        Given that I sign up and log in as a valid student
+        Then I request update event 1 with the following and recieve code 403
+            | title | Mock interview (2)|
+        Then event 1 should have title "Mock interview"
+        Then creating an event with the following should return code 403
+            | title | Mock interview (2) |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 17:20:00' |
+        Then there should be 1 events in the DB
+        And I request delete event 1 and recieve code 403
+        Then there should be 1 events in the DB

--- a/server/features/meeting.feature
+++ b/server/features/meeting.feature
@@ -47,6 +47,24 @@ Feature: Meeting
         And the meeting with id 2 will have 'title': 'Another meeting'
         And the meeting with id 2 will have 'owner_id': 2
     
+    Scenario: Create meeting with non-existant event
+        Given that I log in as admin
+        Then creating meeting with the following should return http code 404
+            | title | A meeting |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+            | event_id | 10 |
+    
+    Scenario: Assign meeting rto non-existant event
+        Given that I log in as admin
+        And that I create a meeting with the following
+            | title | A meeting |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+        Then updating meeting 1 with the following should return http code 404
+            | event_id | 10 |
+        
+    
     Scenario: Edit meeting
         # User created with id 1
         Given that I sign up and log in as a valid student

--- a/server/features/step_definitions/availability.rb
+++ b/server/features/step_definitions/availability.rb
@@ -108,3 +108,13 @@ end
 Then("user meeting {int} should not exist") do |id|
   expect(UserMeeting.find_by_id(id)).to eq(nil)
 end
+
+Then("creating an availability with the following should return status {int}") do |code, table|
+  ret = page.driver.post("/availabilities", { "availability": table.rows_hash })
+  expect(ret.status).to eq(code)
+end
+
+Then("updating an availability {int} with the following should return status {int}") do |id, code, table|
+  ret = page.driver.put("/availabilities/#{id}", { "availability": table.rows_hash })
+  expect(ret.status).to eq(code)
+end

--- a/server/features/step_definitions/event.rb
+++ b/server/features/step_definitions/event.rb
@@ -1,0 +1,29 @@
+Then("creating an event with the following should return code {int}") do |code, table|
+  ret = page.driver.post("/events", { 'event': table.rows_hash })
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(code)
+end
+
+Then("there should be {int} events in the DB") do |count|
+  ret = page.driver.get("/events")
+  ret_body = JSON.parse ret.body
+  expect(ret_body["events"].size).to eq(count)
+end
+
+Then("event {int} should have title {string}") do |id, title|
+  ret = page.driver.get("/events/#{id}")
+  ret_body = JSON.parse ret.body
+  expect(ret_body["event"]["title"]).to eq(title)
+end
+
+Then("I request update event {int} with the following and recieve code {int}") do |id, code, table|
+  ret = page.driver.put("/events/#{id}", { 'event': table.rows_hash })
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(code)
+end
+
+Then("I request delete event {int} and recieve code {int}") do |id, code|
+  ret = page.driver.delete("/events/#{id}")
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(code)
+end

--- a/server/features/step_definitions/meeting.rb
+++ b/server/features/step_definitions/meeting.rb
@@ -61,6 +61,18 @@ Then("creating meetings should result in not authenticated error") do
   expect(ret_body["errors"]).to eq(["User not logged in"])
 end
 
+Then("creating meeting with the following should return http code {int}") do |code, table|
+  ret = page.driver.post("/meetings", { "meeting": table.rows_hash })
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(code)
+end
+
+Then("updating meeting {int} with the following should return http code {int}") do |meeting_id, code, table|
+  ret = page.driver.put("/meetings/#{meeting_id}", { "meeting": table.rows_hash })
+  ret_body = JSON.parse ret.body
+  expect(ret.status).to eq(code)
+end
+
 Given("that I create a meeting with the following") do |table|
   ret = page.driver.post("/meetings", { 'meeting': table.rows_hash })
 end

--- a/server/spec/models/event_signup_spec.rb
+++ b/server/spec/models/event_signup_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe EventSignup, type: :model do
+  it "is valid with valid attributes" do
+    user = User.create(firstname: "user1", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "admin")
+    event = Event.create(title: "Event 1", description: "This is event 1", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00")
+    expect(EventSignup.create(user: user, event: event)).to be_valid
+  end
+
+  it "is invalid with invalid attributes" do
+    user = User.create(firstname: "user1", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "admin")
+    event = Event.create(title: "Event 1", description: "This is event 1", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00")
+    expect(EventSignup.create(user_id: user.id + 100, event: event)).to_not be_valid
+  end
+
+  it "is should fetch association correctly" do
+    user1 = User.create(firstname: "user1", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "admin")
+    user2 = User.create(firstname: "user2", lastname: "doe", email: "user2@hello.com", password: "something", usertype: "admin")
+    user3 = User.create(firstname: "user3", lastname: "doe", email: "user3@hello.com", password: "something", usertype: "admin")
+    event1 = Event.create(title: "Event 1", description: "This is event 1", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00")
+    event2 = Event.create(title: "Event 2", description: "This is event 2", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00")
+    expect(EventSignup.create(user: user1, event: event1)).to be_valid
+    expect(EventSignup.create(user: user2, event: event1)).to be_valid
+    expect(EventSignup.create(user: user2, event: event2)).to be_valid
+    expect(EventSignup.create(user: user3, event: event2)).to be_valid
+    expect(event1.users).to match_array([user1, user2])
+    expect(event2.users).to match_array([user2, user3])
+    expect(user1.events).to match_array([event1])
+    expect(user2.events).to match_array([event1, event2])
+    expect(user3.events).to match_array([event2])
+  end
+end

--- a/server/spec/models/event_spec.rb
+++ b/server/spec/models/event_spec.rb
@@ -7,4 +7,52 @@ RSpec.describe Event, type: :model do
   it "is invalid with invalid attributes" do
     expect(Event.create(start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 11:20:00")).to_not be_valid
   end
+
+  it "should display event meetings correctly" do
+    user1 = User.create(firstname: "user1", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "admin")
+    event1 = Event.create(start_time: "2022-10-18 11:10:00", end_time: "2022-10-18 11:20:00")
+    event2 = Event.create(start_time: "2022-10-18 11:10:00", end_time: "2022-10-18 11:20:00")
+    expect(event1).to be_valid
+    expect(event2).to be_valid
+
+    meeting1 = Meeting.create(owner_id: user1.id, title: "meeting1", start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:20:00", event_id: event1.id)
+    meeting2 = Meeting.create(owner_id: user1.id, title: "meeting2", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00", event_id: event1.id)
+    meeting3 = Meeting.create(owner_id: user1.id, title: "meeting3", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00", event_id: event2.id)
+    meeting4 = Meeting.create(owner_id: user1.id, title: "meeting4", start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00", event_id: event2.id)
+    expect(meeting1).to be_valid
+    expect(meeting2).to be_valid
+    expect(meeting3).to be_valid
+    expect(meeting4).to be_valid
+    expect(meeting1.event).to eq(event1)
+    expect(meeting2.event).to eq(event1)
+    expect(meeting3.event).to eq(event2)
+    expect(meeting4.event).to eq(event2)
+
+    expect(event1.meetings).to match_array([meeting1, meeting2])
+    expect(event2.meetings).to match_array([meeting3, meeting4])
+  end
+
+  it "should display event availabilities correctly" do
+    user1 = User.create(firstname: "user1", lastname: "doe", email: "user1@hello.com", password: "something", usertype: "company representative")
+    event1 = Event.create(start_time: "2022-10-18 11:10:00", end_time: "2022-10-18 11:20:00")
+    event2 = Event.create(start_time: "2022-10-18 11:10:00", end_time: "2022-10-18 11:20:00")
+    expect(event1).to be_valid
+    expect(event2).to be_valid
+
+    availability1 = Availability.create(user_id: user1.id, start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:20:00", event_id: event1.id)
+    availability2 = Availability.create(user_id: user1.id, start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00", event_id: event1.id)
+    availability3 = Availability.create(user_id: user1.id, start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00", event_id: event2.id)
+    availability4 = Availability.create(user_id: user1.id, start_time: "2022-10-18 14:30:00", end_time: "2022-10-18 14:50:00", event_id: event2.id)
+    expect(availability1).to be_valid
+    expect(availability2).to be_valid
+    expect(availability3).to be_valid
+    expect(availability4).to be_valid
+    expect(availability1.event).to eq(event1)
+    expect(availability2.event).to eq(event1)
+    expect(availability3.event).to eq(event2)
+    expect(availability4.event).to eq(event2)
+
+    expect(event1.availabilities).to match_array([availability1, availability2])
+    expect(event2.availabilities).to match_array([availability3, availability4])
+  end
 end

--- a/server/spec/models/event_spec.rb
+++ b/server/spec/models/event_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Event, type: :model do
+  it "is valid with valid attributes" do
+    expect(Event.create(start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 14:20:00")).to be_valid
+  end
+  it "is invalid with invalid attributes" do
+    expect(Event.create(start_time: "2022-10-18 14:10:00", end_time: "2022-10-18 11:20:00")).to_not be_valid
+  end
+end


### PR DESCRIPTION
- Add event model
  - Descriptive attributes: title, description
- Users can sign up to events
- Availabilities now belong to events
  - This isn't forced yet. If forced, too many tests have to be changed. Will address in another PR
- Meetings now belong to events
  - This isn't forced yet. If forced, too many tests have to be changed. Will address in another PR
- API doc to be updated.

TODO: meetings and availabilities are not cascade-deleted on event updates and deletions. This is to be addressed in another PR.
