### PR TITLE
Allowlist Various Changes

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -56,3 +56,6 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
+
+# Allow like clauses for active record
+gem 'activerecord-like'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (7.0.4)
       activemodel (= 7.0.4)
       activesupport (= 7.0.4)
+    activerecord-like (7.0.0)
+      activerecord (~> 7.0, >= 7.0.0)
     activestorage (7.0.4)
       actionpack (= 7.0.4)
       activejob (= 7.0.4)
@@ -258,6 +260,7 @@ PLATFORMS
   x64-mingw-ucrt
 
 DEPENDENCIES
+  activerecord-like
   bcrypt (~> 3.1.7)
   bootsnap
   cucumber-rails

--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -1,6 +1,7 @@
 class AllowlistDomainsController < ApplicationController
   before_action :confirm_user_logged_in
-  before_action :confirm_requester_is_rep_or_admin, only: [:create, :delete, :index, :show]
+  before_action :confirm_requester_is_primary_contact_or_admin, only: [:create, :delete]
+  before_action :confirm_requester_is_rep_or_admin, only: [:index, :show]
   before_action :confirm_uniquness, only: [:create]
 
   def index
@@ -109,12 +110,25 @@ class AllowlistDomainsController < ApplicationController
     end
   end
 
-  def confirm_requester_is_rep_or_admin()
+
+  def confirm_requester_is_primary_contact_or_admin()
     if !(current_user.usertype == "admin" ||
          (current_user.usertype == "company representative" &&
           current_user.company != nil &&
           current_user.allowlist_email != nil &&
           current_user.allowlist_email.is_primary_contact == true))
+      render json: {
+               errors: ["User does not have previleges for requested action"],
+             }, status: :forbidden
+      return false
+    end
+    return true
+  end
+
+  def confirm_requester_is_rep_or_admin()
+    if !(current_user.usertype == "admin" ||
+         (current_user.usertype == "company representative" &&
+          current_user.company != nil))
       render json: {
                errors: ["User does not have previleges for requested action"],
              }, status: :forbidden

--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -55,6 +55,9 @@ class AllowlistDomainsController < ApplicationController
       company = nil
     end
 
+    p current_user
+    p company
+
     @domain = AllowlistDomain.new(domain_params)
     @domain.company_id = company ? company.id : nil
     if @domain.save

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -1,6 +1,7 @@
 class AllowlistEmailsController < ApplicationController
   before_action :confirm_user_logged_in
   before_action :confirm_requester_is_rep_or_admin, only: [:create, :delete, :index, :show, :transferPrimaryContact]
+  before_action :confirm_uniquness, only: [:create]
 
   def index
     @emails = AllowlistEmail.all
@@ -19,7 +20,7 @@ class AllowlistEmailsController < ApplicationController
 
     if @emails
       render json: {
-               emails: @emails,
+                allowlist_emails: @emails,
              }, status: :ok
     else
       render json: {
@@ -36,7 +37,7 @@ class AllowlistEmailsController < ApplicationController
 
     if @email
       render json: {
-               email: @email,
+                allowlist_email: @email,
              }, status: :ok
     else
       render json: {
@@ -48,8 +49,8 @@ class AllowlistEmailsController < ApplicationController
   def create
     if current_user.usertype == "company representative"
       company = current_user.company
-    elsif params[:email][:company_id] != nil and current_user.usertype == "admin"
-      company = Company.find_by_id(params[:email][:company_id])
+    elsif params[:allowlist_email][:company_id] != nil and current_user.usertype == "admin"
+      company = Company.find_by_id(params[:allowlist_email][:company_id])
     else
       company = nil
     end
@@ -67,7 +68,7 @@ class AllowlistEmailsController < ApplicationController
       end
 
       render json: {
-               email: @email,
+                allowlist_email: @email,
              }, status: :created
     else
       render json: {
@@ -101,27 +102,29 @@ class AllowlistEmailsController < ApplicationController
     if current_user.usertype == "admin"
       info = admin_transfer_params
       to_user = User.find(info[:to])
-      from_user = User.find(info[:from])
     else
       info = rep_transfer_params
       to_user = User.find(info[:to])
-      from_user = current_user
+      if current_user.allowlist_email.is_primary_contact == false || current_user.company_id != to_user.company_id
+        render json: {
+          errors: ["User does not have previleges for requested action"],
+        }, status: :forbidden
+        return
+      end
     end
 
     if (to_user == nil ||
-        from_user == nil ||
         to_user.allowlist_email == nil ||
-        from_user.allowlist_email == nil ||
-        from_user.allowlist_email.isPrimaryContact == false ||
-        to_user.company_id != from_user.company_id ||
-        to_user.usertype != "company representative" ||
-        from_user.usertype != "company representative")
+        to_user.usertype != "company representative")
       render json: {
                errors: ["User does not have previleges for requested action"],
              }, status: :forbidden
     else
-      to_user.allowlist_email.update(isPrimaryContact: 1)
-      from_user.allowlist_email.update(isPrimaryContact: 0)
+      from_users = to_user.company.users.where.not(allowlist_email_id: nil)
+      for fu in from_users
+        fu.allowlist_email.update(is_primary_contact: 0)
+      end
+      to_user.allowlist_email.update(is_primary_contact: 1)
 
       render json: {
                message: "transfer success",
@@ -144,7 +147,7 @@ class AllowlistEmailsController < ApplicationController
          (current_user.usertype == "company representative" &&
           current_user.company != nil &&
           current_user.allowlist_email != nil &&
-          current_user.allowlist_email.isPrimaryContact == true))
+          current_user.allowlist_email.is_primary_contact == true))
       render json: {
                errors: ["User does not have previleges for requested action"],
              }, status: :forbidden
@@ -154,18 +157,33 @@ class AllowlistEmailsController < ApplicationController
   end
 
   def email_params
-    if params[:email] != nil && params[:email][:email] != nil
-      params[:email][:email] = params[:email][:email].downcase
-    end
     if @current_user.usertype != "admin"
-      params[:email][:isPrimaryContact] = false
-      params[:email][:usertype] = "company representative"
+      params[:allowlist_email][:is_primary_contact] = false
+      params[:allowlist_email][:usertype] = "company representative"
     end
-    params.require(:email).permit(:email, :usertype, :isPrimaryContact)
+    params.require(:allowlist_email).permit(:email, :usertype, :is_primary_contact)
+  end
+
+  def confirm_uniquness
+
+    ep = email_params
+    
+    email = AllowlistEmail.where(usertype: params[:allowlist_email][:usertype]).where.like(email: params[:allowlist_email][:email])
+    if params[:allowlist_email][:company_id]
+      email = email.where(company_id: params[:allowlist_email][:company_id])
+    end
+
+    if email.first 
+      render json: {
+        errors: ["Allowlist entry already exists"],
+      }, status: :forbidden
+      return false
+    end
+    return true
   end
 
   def admin_transfer_params
-    params.permit(:to, :from)
+    params.permit(:to)
   end
 
   def rep_transfer_params

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -122,9 +122,9 @@ class AllowlistEmailsController < ApplicationController
     else
       from_users = to_user.company.users.where.not(allowlist_email_id: nil)
       for fu in from_users
-        fu.allowlist_email.update(is_primary_contact: 0)
+        fu.allowlist_email.update(is_primary_contact: false)
       end
-      to_user.allowlist_email.update(is_primary_contact: 1)
+      to_user.allowlist_email.update(is_primary_contact: true)
 
       render json: {
                message: "transfer success",

--- a/server/app/controllers/allowlist_emails_controller.rb
+++ b/server/app/controllers/allowlist_emails_controller.rb
@@ -1,6 +1,7 @@
 class AllowlistEmailsController < ApplicationController
   before_action :confirm_user_logged_in
-  before_action :confirm_requester_is_rep_or_admin, only: [:create, :delete, :index, :show, :transferPrimaryContact]
+  before_action :confirm_requester_is_primary_contact_or_admin, only: [:create, :delete, :transferPrimaryContact]
+  before_action :confirm_requester_is_rep_or_admin, only: [:index, :show]
   before_action :confirm_uniquness, only: [:create]
 
   def index
@@ -142,12 +143,24 @@ class AllowlistEmailsController < ApplicationController
     end
   end
 
-  def confirm_requester_is_rep_or_admin()
+  def confirm_requester_is_primary_contact_or_admin()
     if !(current_user.usertype == "admin" ||
          (current_user.usertype == "company representative" &&
           current_user.company != nil &&
           current_user.allowlist_email != nil &&
           current_user.allowlist_email.is_primary_contact == true))
+      render json: {
+               errors: ["User does not have previleges for requested action"],
+             }, status: :forbidden
+      return false
+    end
+    return true
+  end
+
+  def confirm_requester_is_rep_or_admin()
+    if !(current_user.usertype == "admin" ||
+         (current_user.usertype == "company representative" &&
+          current_user.company != nil))
       render json: {
                errors: ["User does not have previleges for requested action"],
              }, status: :forbidden

--- a/server/app/controllers/users_controller.rb
+++ b/server/app/controllers/users_controller.rb
@@ -44,7 +44,7 @@ class UsersController < ApplicationController
     params = CGI.parse(uri.query)
     @user = nil
     if params.key?("email")
-      @user = User.find_by_email(params["email"][0])
+      @user = User.where.like(email: params["email"][0]).first
     elsif params.key?("firstname") and params.key?("lastname")
       # Use this only for testing purposes as firstname-lastname pair is not guarenteed to be unique.
       @user = User.find_by firstname: params["firstname"], lastname: params["lastname"]
@@ -70,7 +70,7 @@ class UsersController < ApplicationController
     end
 
     # Check for email uniqueness
-    existing_user = User.find_by_email(params["user"]["email"]) # TODO 'and usertype == params[usertype]'
+    existing_user = User.where.like(email: params["user"]["email"]).first # TODO 'and usertype == params[usertype]'
     if existing_user != nil # TODO once multiple users, allow email reuse for different account types (eg. I can have an admin and a student account)
       return render json: {
                errors: ["Email already in use"],
@@ -78,8 +78,8 @@ class UsersController < ApplicationController
     end
 
     # Check that the email is allowed
-    exact_match = AllowlistEmail.find_by(email: params["user"]["email"].downcase, usertype: params["user"]["usertype"])
-    domain_match = AllowlistDomain.find_by(email_domain: params["user"]["email"].downcase.split("@").last, usertype: params["user"]["usertype"])
+    exact_match = AllowlistEmail.where(usertype: params["user"]["usertype"]).where.like(email: params["user"]["email"]).first
+    domain_match = AllowlistDomain.where(usertype: params["user"]["usertype"]).where.like(domain: params["user"]["email"].split("@").last).first
     if exact_match == nil && domain_match == nil
       return render json: {
                errors: ["Email not allowed"],

--- a/server/app/models/allowlist_domain.rb
+++ b/server/app/models/allowlist_domain.rb
@@ -1,7 +1,7 @@
 class AllowlistDomain < ApplicationRecord
-    validates :email_domain, presence: true
-    validates :email_domain, uniqueness: { scope: [:usertype, :company_id] }
-    validates :email_domain, format: { with: /\A((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
+    validates :domain, presence: true
+    validates :domain, uniqueness: { scope: [:usertype, :company_id] }
+    validates :domain, format: { with: /\A((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
     validates :usertype,
     :inclusion  => { :in => [ 'company representative', 'student', 'faculty', 'admin', 'volunteer'],
                      :message    => "%{value} is not a valid usertype" }

--- a/server/db/migrate/20221130063701_fix_allowlist_domain_column_name.rb
+++ b/server/db/migrate/20221130063701_fix_allowlist_domain_column_name.rb
@@ -1,0 +1,5 @@
+class FixAllowlistDomainColumnName < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :allowlist_domains, :email_domain, :domain
+  end
+end

--- a/server/db/migrate/20221130064213_fix_allowlist_email_primary_contact_column.rb
+++ b/server/db/migrate/20221130064213_fix_allowlist_email_primary_contact_column.rb
@@ -1,0 +1,5 @@
+class FixAllowlistEmailPrimaryContactColumn < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :allowlist_emails, :isPrimaryContact, :is_primary_contact
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_18_021729) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_30_064213) do
   create_table "allowlist_domains", force: :cascade do |t|
-    t.string "email_domain"
+    t.string "domain"
     t.string "usertype"
     t.integer "company_id"
     t.index ["company_id"], name: "index_allowlist_domains_on_company_id"
-    t.index ["email_domain", "usertype", "company_id"], name: "domain_usertype_company", unique: true
+    t.index ["domain", "usertype", "company_id"], name: "domain_usertype_company", unique: true
   end
 
   create_table "allowlist_emails", force: :cascade do |t|
@@ -25,7 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_021729) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "company_id"
-    t.boolean "isPrimaryContact", default: false
+    t.boolean "is_primary_contact", default: false
     t.index ["company_id"], name: "index_allowlist_emails_on_company_id"
     t.index ["email", "usertype", "company_id"], name: "email_usertype_company", unique: true
   end

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -548,6 +548,37 @@ Feature: Allowlist Management
         And that I log in as admin
         Then the primary contact for the company with id 1 should have email test@test.com
 
+    Scenario: A rep transfers primary contact to a user allowed by domain
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new company domain test2.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test2.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test@test.com
+        And I should see 1 new email in the database
+        And that the user verified their email test@test.com
+        And that I log in with email test@test.com and password password1!
+        And I transfer my primary contact role to user with id 3
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test2@test2.com
+        And I should see 2 new email in the database
+
     Scenario: A student signs up to a newly allowed email and email, which is then deleted, but he remains
         Given that I log in as admin
         And I allow a new domain test.com for usertype student

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -89,6 +89,7 @@ Feature: Allowlist Management
             | email | test@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         And I allow a new domain test2.com for usertype company representative
         And that I log in as admin

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -27,6 +27,18 @@ Feature: Allowlist Management
             | usertype | student |
         Then the user with firstname james and lastname bond should be found in the user DB
 
+    Scenario: A student signs up to a newly allowed domain with funny casing
+        Given that I log in as admin
+        And I allow a new domain test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@tEsT.cOm |
+            | usertype | student |
+        Then the user with firstname james and lastname bond should be found in the user DB
+
     Scenario: A student signs up to a newly allowed domain, which is then deleted
         Given that I log in as admin
         And I allow a new domain test.com for usertype student
@@ -82,6 +94,7 @@ Feature: Allowlist Management
         And that I log in as admin
         Then I should see 4 domain in the database
         And the company with id 1 should have 1 reps
+        And the primary contact for the company with id 1 should have email test@test.com
 
     Scenario: An admin allows the same domain for a multiple company
         Given that I log in as admin
@@ -99,11 +112,25 @@ Feature: Allowlist Management
         And I fail to allow a new company domain test.com for usertype company representative for company id 1        
         Then I should see 4 domain in the database
 
+    Scenario: An admin allows the same domain for a the same company with funny casing
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company domain test.com for usertype company representative for company id 1        
+        And I fail to allow a new company domain tEsT.cOm for usertype company representative for company id 1        
+        Then I should see 4 domain in the database
+
     Scenario: An admin allows the same email for a the same company
         Given that I log in as admin
         And there is a company with id 1
         And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
         And I fail to allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        Then I should see 1 new email in the database
+
+    Scenario: An admin allows the same email for a the same company with funny casing
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I fail to allow a new primary contact company email tEsT@tEsT.cOm for usertype company representative for company id 1
         Then I should see 1 new email in the database
 
     Scenario: An admin allows the same email for a multiple company
@@ -156,6 +183,18 @@ Feature: Allowlist Management
             | password | password1! |
             | password_confirmation | password1! |
             | email | test@test.com |
+            | usertype | student |
+        Then the user with firstname james and lastname bond should be found in the user DB
+
+    Scenario: A student signs up to a newly allowed email with funny casing
+        Given that I log in as admin
+        And I allow a new email test@test.com for usertype student
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | tEsT@tEsT.cOm |
             | usertype | student |
         Then the user with firstname james and lastname bond should be found in the user DB
 
@@ -366,6 +405,8 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test@test.com
         And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 2 new email in the database
@@ -379,6 +420,8 @@ Feature: Allowlist Management
         And I should get a 403 code from the email database
         And that I log in with email test2@test.com and password password1!
         Then I should see 2 new email in the database
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test2@test.com
 
 
     Scenario: An admin transfers primary contact correctly
@@ -402,6 +445,8 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 1 |
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test@test.com
         And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
         Then I should see 2 new email in the database
@@ -410,12 +455,14 @@ Feature: Allowlist Management
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
         And that I log in as admin
-        And I transfer primary contact role to user with id 3 from user with id 2
+        And I transfer primary contact role to user with id 3
         And that I log in with email test@test.com and password password1!
         Then I should get a 403 code from the domain database
         And I should get a 403 code from the email database
         And that I log in with email test2@test.com and password password1!
         Then I should see 2 new email in the database
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test2@test.com
 
     Scenario: A rep fails  to transfer primary contact
         Given that I log in as admin
@@ -442,34 +489,7 @@ Feature: Allowlist Management
         And that I log in with email test@test.com and password password1!
         And I fail to transfer my primary contact role to user with id 3
 
-
-    Scenario: An admin transfers primary contact incorrectly
-        Given that I log in as admin
-        And there is a company with id 1
-        And there is a company with id 2
-        And I allow a new company email test@test.com for usertype company representative for company id 1
-        And I allow a new company email test2@test.com for usertype company representative for company id 1
-        And I allow a new company email test3@test.com for usertype company representative for company id 2
-        And that I sign up with the following
-            | firstname | james |
-            | lastname | bond |
-            | password | password1! |
-            | password_confirmation | password1! |
-            | email | test@test.com |
-            | usertype | company representative |
-            | company_id | 1 |
-        And that I sign up with the following
-            | firstname | james |
-            | lastname | bond |
-            | password | password1! |
-            | password_confirmation | password1! |
-            | email | test2@test.com |
-            | usertype | company representative |
-            | company_id | 1 |
-        And that I log in as admin
-        And I fail to transfer primary contact role to user with id 3 from user with id 2
-
-   Scenario: An admin transfers primary contact incorrectly
+    Scenario: A rep fails  to transfer primary contact
         Given that I log in as admin
         And there is a company with id 1
         And there is a company with id 2
@@ -491,15 +511,13 @@ Feature: Allowlist Management
             | email | test2@test.com |
             | usertype | company representative |
             | company_id | 2 |
+        And that I log in as admin
+        Then the primary contact for the company with id 1 should have email test@test.com
         And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
-        Then I should see 1 new email in the database
-        And that the user verified their email test2@test.com
-        And that I log in with email test2@test.com and password password1!
-        Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        And I fail to transfer my primary contact role to user with id 3
         And that I log in as admin
-        And I fail to transfer primary contact role to user with id 3 from user with id 2
+        Then the primary contact for the company with id 1 should have email test@test.com
 
     Scenario: A student signs up to a newly allowed email and email, which is then deleted, but he remains
         Given that I log in as admin

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -305,6 +305,8 @@ Feature: Allowlist Management
         And I allow a new company domain test3.com for usertype company representative for company id 2
         And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
         And I allow a new primary contact company email test2@test2.com for usertype company representative for company id 2
+        Then I should see 6 domain in the database
+        And I should see 2 new email in the database
         And that I sign up with the following
             | firstname | james |
             | lastname | bond |
@@ -338,6 +340,7 @@ Feature: Allowlist Management
         And I allow a new company domain test.com for usertype company representative for company id 1
         And I allow a new company domain test2.com for usertype company representative for company id 2
         And I allow a new company domain test3.com for usertype company representative for company id 2
+        Then I should see 6 domain in the database
         And that I sign up with the following
             | firstname | james |
             | lastname | bond |
@@ -348,8 +351,9 @@ Feature: Allowlist Management
             | company_id | 1 |
         And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
-        Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
+        And I should see 1 domain in the database
         And that I sign up with the following
             | firstname | james |
             | lastname | bond |
@@ -360,8 +364,19 @@ Feature: Allowlist Management
             | company_id | 2 |
         And that the user verified their email test2@test2.com
         And that I log in with email test2@test2.com and password password1!
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
+        And I should see 2 domain in the database
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@tamu.edu |
+            | usertype | student |
+        And that the user verified their email test@tamu.edu
+        And that I log in with email test@tamu.edu and password password1!
         Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
 
 
     Scenario: Multiple company emails are added and only appropriate users can see them
@@ -371,6 +386,7 @@ Feature: Allowlist Management
         And I allow a new company domain test0.com for usertype company representative for company id 1
         And I allow a new company domain test02.com for usertype company representative for company id 2
         And I allow a new company email test@test.com for usertype company representative for company id 1
+        Then I should see 5 domain in the database
         And that I sign up with the following
             | firstname | james |
             | lastname | bond |
@@ -381,8 +397,21 @@ Feature: Allowlist Management
             | company_id | 1 |
         And that the user verified their email test@test.com
         And that I log in with email test@test.com and password password1!
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
+        And I should see 1 domain in the database
+        And I should see 1 new email in the database
+        And that I sign up with the following
+            | firstname | james |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@tamu.edu |
+            | usertype | student |
+        And that the user verified their email test@tamu.edu
+        And that I log in with email test@tamu.edu and password password1!
         Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        
 
     Scenario: A rep transfers primary contact correctly
         Given that I log in as admin
@@ -412,12 +441,12 @@ Feature: Allowlist Management
         Then I should see 2 new email in the database
         And that the user verified their email test2@test.com
         And that I log in with email test2@test.com and password password1!
-        Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
         And that I log in with email test@test.com and password password1!
         And I transfer my primary contact role to user with id 3
-        Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
         And that I log in with email test2@test.com and password password1!
         Then I should see 2 new email in the database
         And that I log in as admin
@@ -452,19 +481,19 @@ Feature: Allowlist Management
         Then I should see 2 new email in the database
         And that the user verified their email test2@test.com
         And that I log in with email test2@test.com and password password1!
-        Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
         And that I log in as admin
         And I transfer primary contact role to user with id 3
         And that I log in with email test@test.com and password password1!
-        Then I should get a 403 code from the domain database
-        And I should get a 403 code from the email database
+        Then I should get a 200 code from the domain database
+        And I should get a 200 code from the email database
         And that I log in with email test2@test.com and password password1!
         Then I should see 2 new email in the database
         And that I log in as admin
         Then the primary contact for the company with id 1 should have email test2@test.com
 
-    Scenario: A rep fails  to transfer primary contact
+    Scenario: A rep fails to transfer primary contact
         Given that I log in as admin
         And there is a company with id 1
         And I allow a new company email test@test.com for usertype company representative for company id 1
@@ -489,7 +518,7 @@ Feature: Allowlist Management
         And that I log in with email test@test.com and password password1!
         And I fail to transfer my primary contact role to user with id 3
 
-    Scenario: A rep fails  to transfer primary contact
+    Scenario: A rep fails to transfer primary contact
         Given that I log in as admin
         And there is a company with id 1
         And there is a company with id 2

--- a/server/features/signup.feature
+++ b/server/features/signup.feature
@@ -11,6 +11,7 @@ Feature: Student signup
             | password_confirmation | password1! |
             | email | test@tamu.edu |
             | usertype | student |
+        And that I log in as admin
         Then the user with email test@tamu.edu should be found in the user DB
         And the user with email test@tamu.edu should be marked as not verified
         And there should be 1 sent emails
@@ -24,6 +25,7 @@ Feature: Student signup
             | email | test@tamu.edu |
             | usertype | student |
         Given that an user signs up as a valid student
+        And that I log in as admin
         Then the user with email test@tamu.edu should NOT be found in the user DB
     
     Scenario: Show students

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -12,27 +12,27 @@ Then('the company with id {int} should have {int} reps') do |id, int|
   end
 
 Given /^I allow a new domain ([^\']*) for usertype ([^\']*)$/ do |domain, usertype|
-  ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype}})
+  ret = page.driver.post('/allowlist_domains', {"allowlist_domain":{"domain":domain,"usertype":usertype}})
   ret_body = JSON.parse ret.body
   expect(ret.status).to eq(201)
 end
 
 Given /^I fail to allow a new domain ([^\']*) for usertype ([^\']*)$/ do |domain, usertype|
-    ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype}})
+    ret = page.driver.post('/allowlist_domains', {"allowlist_domain":{"domain":domain,"usertype":usertype}})
     ret_body = JSON.parse ret.body
-    expect(ret.status).to eq(500)
+    expect(ret.status).to eq(403)
   end
 
 Given /^I allow a new company domain ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |domain, usertype, int|
-    ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype, "company_id":int}})
+    ret = page.driver.post('/allowlist_domains', {"allowlist_domain":{"domain":domain,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
 end
 
 Given /^I fail to allow a new company domain ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |domain, usertype, int|
-    ret = page.driver.post('/allowlist_domains', {"domain":{"email_domain":domain,"usertype":usertype, "company_id":int}})
+    ret = page.driver.post('/allowlist_domains', {"allowlist_domain":{"domain":domain,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
-    expect(ret.status).to eq(500)
+    expect(ret.status).to eq(403)
 end
 
 Given /^I delete the allowed domain with index 4$/ do 
@@ -44,19 +44,19 @@ end
 Then('I should see {int} domain in the database') do |int|
   ret = page.driver.get('/allowlist_domains')
   ret_body = JSON.parse ret.body
-  expect(ret_body['domains'].size).to eq(int)
+  expect(ret_body['allowlist_domains'].size).to eq(int)
 end
 
 Then("I should see {int} domain with usertype: student in the database") do |int|
     ret = page.driver.get("/allowlist_domains/?usertype=student")
     ret_body = JSON.parse ret.body
-    expect(ret_body['domains'].size).to eq(int)
+    expect(ret_body['allowlist_domains'].size).to eq(int)
 end
 
 Then("I should see {int} domain with company_id: 1 in the database") do |int|
     ret = page.driver.get("/allowlist_domains/?company_id=1")
     ret_body = JSON.parse ret.body
-    expect(ret_body['domains'].size).to eq(int)
+    expect(ret_body['allowlist_domains'].size).to eq(int)
 end
 
 Then('I should see a domain with index {int} in the database') do |int|
@@ -66,33 +66,33 @@ Then('I should see a domain with index {int} in the database') do |int|
   end
 
 Given /^I allow a new email ([^\']*) for usertype ([^\']*)$/ do |email, usertype|
-    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
 end
 
 Given /^I allow a new company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
-    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
 end
 
 Given /^I fail to allow a new company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
-    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int}})
     ret_body = JSON.parse ret.body
-    expect(ret.status).to eq(500)
+    expect(ret.status).to eq(403)
 end
 
 Given /^I allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
-    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int, "isPrimaryContact":1}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int, "is_primary_contact":1}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
 end
 
 Given /^I fail to allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
-    ret = page.driver.post('/allowlist_emails', {"email":{"email":email,"usertype":usertype, "company_id":int, "isPrimaryContact":1}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int, "is_primary_contact":1}})
     ret_body = JSON.parse ret.body
-    expect(ret.status).to eq(500)
+    expect(ret.status).to eq(403)
 end
 
 Given /^I delete the allowed email with index 1$/ do 
@@ -104,19 +104,19 @@ end
 Then('I should see {int} new email in the database') do |int|
 ret = page.driver.get('/allowlist_emails')
 ret_body = JSON.parse ret.body
-expect(ret_body['emails'].size).to eq(int)
+expect(ret_body['allowlist_emails'].size).to eq(int)
 end
 
 Then('I should see {int} email with usertype: student in the database') do |int|
     ret = page.driver.get('/allowlist_emails/?usertype=student')
     ret_body = JSON.parse ret.body
-    expect(ret_body['emails'].size).to eq(int)
+    expect(ret_body['allowlist_emails'].size).to eq(int)
 end
 
 Then('I should see {int} email with company_id: 1 in the database') do |int|
     ret = page.driver.get('/allowlist_emails/?company_id=1')
     ret_body = JSON.parse ret.body
-    expect(ret_body['emails'].size).to eq(int)
+    expect(ret_body['allowlist_emails'].size).to eq(int)
 end
 
 Then('I should see an email with index {int} in the database') do |int|
@@ -143,8 +143,8 @@ Given('I transfer my primary contact role to user with id {int}') do |int|
     expect(ret.status).to eq(200)
 end
 
-Given('I transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
-    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int1, "from":int2})
+Given('I transfer primary contact role to user with id {int}') do |int1|
+    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int1})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(200)
 end
@@ -155,10 +155,18 @@ Given('I fail to transfer my primary contact role to user with id {int}') do |in
     expect(ret.status).to eq(403)
 end
 
-Given('I fail to transfer primary contact role to user with id {int} from user with id {int}') do |int1, int2|
-    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int1, "from":int2})
+Given('I fail to transfer primary contact role to user with id {int}') do |int1|
+    ret = page.driver.post('/allowlist_emails/transfer_primary_contact', {"to":int1})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(403)
+end
+
+Then /^the primary contact for the company with id ([0-9]*) should have email ([^\']*)$/ do |cid, email|
+    ret = page.driver.get("/companies")
+    ret_body = JSON.parse ret.body
+    ae = ret_body["companies"][0]["allowlist_emails"].select { |u| u["is_primary_contact"] == true }
+    expect(ae.size == 1).to eq(true)
+    expect(ae[0]["email"]).to eq(email)
 end
 
 Then("I should see allowlist emails and domains in company 1 when indexing") do
@@ -166,7 +174,6 @@ Then("I should see allowlist emails and domains in company 1 when indexing") do
     ret_body = JSON.parse ret.body
     ae = ret_body["companies"][0]["allowlist_emails"]
     ad = ret_body["companies"][0]["allowlist_domains"]
-    p ret_body
     expect(ae.size > 0).to eq(true)
     expect(ad.size > 0).to eq(true)
 end
@@ -176,7 +183,6 @@ Then("I should not see allowlist emails and domains in company 1 when indexing")
     ret_body = JSON.parse ret.body
     ae = ret_body["companies"][0]["allowlist_emails"]
     ad = ret_body["companies"][0]["allowlist_domains"]
-    p ret_body
     expect(ae).to eq(nil)
     expect(ad).to eq(nil)
 end

--- a/server/features/step_definitions/allowlist.rb
+++ b/server/features/step_definitions/allowlist.rb
@@ -84,13 +84,13 @@ Given /^I fail to allow a new company email ([^\']*) for usertype ([^\']*) for c
 end
 
 Given /^I allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
-    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int, "is_primary_contact":1}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int, "is_primary_contact":true}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(201)
 end
 
 Given /^I fail to allow a new primary contact company email ([^\']*) for usertype ([^\']*) for company id ([0-9]*)$/ do |email, usertype, int|
-    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int, "is_primary_contact":1}})
+    ret = page.driver.post('/allowlist_emails', {"allowlist_email":{"email":email,"usertype":usertype, "company_id":int, "is_primary_contact":true}})
     ret_body = JSON.parse ret.body
     expect(ret.status).to eq(403)
 end

--- a/server/spec/controllers/companies_controller_spec.rb
+++ b/server/spec/controllers/companies_controller_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe CompaniesController, :type => :controller do
         
         Company.create(name: "disney", description: "blah")
         Company.create(id: 3, name: "dreamworks", description: "blah")
-        AllowlistDomain.create(email_domain: "disney.com", usertype: "company representative", company_id: 1)
-        AllowlistDomain.create(email_domain: "waltdisney.com", usertype: "company representative", company_id: 1)
-        AllowlistDomain.create(email_domain: "dreamworks.com", usertype: "company representative", company_id: 3)
+        AllowlistDomain.create(domain: "disney.com", usertype: "company representative", company_id: 1)
+        AllowlistDomain.create(domain: "waltdisney.com", usertype: "company representative", company_id: 1)
+        AllowlistDomain.create(domain: "dreamworks.com", usertype: "company representative", company_id: 3)
         AllowlistEmail.create(email: "a@disney.com", usertype: "company representative", company_id: 1)
         AllowlistEmail.create(email: "b@disney.com", usertype: "company representative", company_id: 1)
         AllowlistEmail.create(email: "a@waltdisney.com", usertype: "company representative", company_id: 1)
@@ -63,12 +63,10 @@ RSpec.describe CompaniesController, :type => :controller do
             session["user_id"] = user.id 
             get :index
             expect(response).to have_http_status(:ok)
-            p 'companies_controller_spec.rb index 1'
             parsed_body = JSON.parse(response.body)
         end
 
         it "should display some fields of 1 or more companies if logged in as student" do
-            p 'companies_controller_spec.rb index 2'
             user=User.find_by email: 'js@student.com' 
             session["user_id"] = user.id 
             expect(user.id).to eq(2)
@@ -83,7 +81,6 @@ RSpec.describe CompaniesController, :type => :controller do
         end
         
         it "should display some fields of 1 or more companies if logged in as representative" do
-            p 'companies_controller_spec.rb index 3'
             user=User.find_by email: 'a@disney.com' 
             session["user_id"] = user.id 
             expect(user.id).to eq(4)
@@ -133,10 +130,10 @@ RSpec.describe CompaniesController, :type => :controller do
             expect(parsed_body["company"]["name"]).to eq('dreamworks')
             expect(parsed_body["company"].keys).to eq(["id", "name", "description", "created_at", "updated_at"])
             parsed_body["allowlist_domains"].each do |record|
-                expect(record.keys).to eq(["id", "email_domain", "usertype", "company_id"])
+                expect(record.keys).to eq(["id", "domain", "usertype", "company_id"])
             end
             parsed_body["allowlist_emails"].each do |record|
-                expect(record.keys).to match_array(["id", "email", "usertype", "company_id", "created_at", "updated_at", "isPrimaryContact"])
+                expect(record.keys).to match_array(["id", "email", "usertype", "company_id", "created_at", "updated_at", "is_primary_contact"])
             end
         end
 
@@ -216,7 +213,6 @@ RSpec.describe CompaniesController, :type => :controller do
 
         it "should display 'no such company found for editting' if that one company is not found" do
             email = 'admin@admin.com'
-            p 'trying "'+email+'", :params with :company part'
 
             user = User.find_by email: email 
             session["user_id"] = user.id
@@ -231,7 +227,6 @@ RSpec.describe CompaniesController, :type => :controller do
     describe "destroy" do
         it "should let admin to delete that company" do
             email = 'admin@admin.com'
-            p 'trying '+email
 
             AllowlistDomain.where(company_id: 1).destroy_all
             AllowlistEmail.where(company_id: 1).destroy_all
@@ -247,7 +242,6 @@ RSpec.describe CompaniesController, :type => :controller do
 
         it "should not let student to delete that company" do
             email = 'js@student.com'
-            p 'trying '+email
 
             AllowlistDomain.where(company_id: 1).destroy_all
             AllowlistEmail.where(company_id: 1).destroy_all
@@ -262,7 +256,6 @@ RSpec.describe CompaniesController, :type => :controller do
 
         it "should not let representative to delete that company" do
             email = 'a@disney.com'
-            p 'trying '+email
 
             AllowlistDomain.where(company_id: 3).destroy_all
             AllowlistEmail.where(company_id: 3).destroy_all
@@ -277,7 +270,6 @@ RSpec.describe CompaniesController, :type => :controller do
 
         it "should display 'no such company found for deleting' if that one company is not found" do
             email = 'admin@admin.com'
-            p 'trying '+email
 
             AllowlistDomain.where(company_id: 10000).destroy_all
             AllowlistEmail.where(company_id: 10000).destroy_all
@@ -295,8 +287,6 @@ RSpec.describe CompaniesController, :type => :controller do
 
     describe "company count, user count" do
         it "shows current count of companies and users in the test db" do
-            p 'current User table contains '+User.count.to_s+' users:'
-            p 'current Company table contains '+Company.count.to_s+' companies:'
         end
     end
 end

--- a/server/spec/models/allowlist_domain_spec.rb
+++ b/server/spec/models/allowlist_domain_spec.rb
@@ -2,22 +2,22 @@ require 'rails_helper'
 
 RSpec.describe AllowlistDomain, type: :model do
   it "is valid with valid attributes" do
-    ad = AllowlistDomain.create(email_domain: "test.edu", usertype: "student")
+    ad = AllowlistDomain.create(domain: "test.edu", usertype: "student")
     expect(ad).to be_valid
   end
 
   it "is valid with valid attributes" do
-    ad = AllowlistDomain.create(email_domain: "test.engr.edu", usertype: "admin")
+    ad = AllowlistDomain.create(domain: "test.engr.edu", usertype: "admin")
     expect(ad).to be_valid
   end
 
   it "is invalid with invalid attributes" do
-    ad = AllowlistDomain.create(email_domain: "blah@test.edu", usertype: "student")
+    ad = AllowlistDomain.create(domain: "blah@test.edu", usertype: "student")
     expect(ad.valid?).to be false
   end
 
   it "is invalid with invalid attributes" do
-    ad = AllowlistDomain.create(email_domain: "test.edu", usertype: "gamer")
+    ad = AllowlistDomain.create(domain: "test.edu", usertype: "gamer")
     expect(ad.valid?).to be false
   end
 end


### PR DESCRIPTION
Changes:
- Allowlist Domains now use {'allowlist_domain':{'domain': ...
- Allowlist Emails now use {'allowlist_email':{'email': ...
- Allowlist Emails now use {'allowlist_email':{'is_primary_contact': ...
- All email checking on the backend is now case insensitive, and email cases are stored as provided by the user
- Primary contact is now unique per company
  - As a result, the transfer primary contact route no longer needs 'from', as it is implied. This also fixes the edge case of a primary contact being allowed but never signing up
- All reps can GET their company's allowlists 
- If transferring primary contact to a user allowed by domain, they will be allowed by email as well

Other:
- Verified true/false works for is_primary_contact
- Removed print statements from rspec