### PR TITLE
Company delete cascades allowlist

### DIFF
--- a/server/app/controllers/allowlist_domains_controller.rb
+++ b/server/app/controllers/allowlist_domains_controller.rb
@@ -56,9 +56,6 @@ class AllowlistDomainsController < ApplicationController
       company = nil
     end
 
-    p current_user
-    p company
-
     @domain = AllowlistDomain.new(domain_params)
     @domain.company_id = company ? company.id : nil
     if @domain.save

--- a/server/app/models/company.rb
+++ b/server/app/models/company.rb
@@ -1,5 +1,5 @@
 class Company < ApplicationRecord
-    has_many :users
+    has_many :users, dependent: :destroy
     has_many :allowlist_domains, dependent: :destroy
     has_many :allowlist_emails, dependent: :destroy
     validates :name, presence: true, uniqueness: true

--- a/server/app/models/company.rb
+++ b/server/app/models/company.rb
@@ -1,6 +1,6 @@
 class Company < ApplicationRecord
     has_many :users
-    has_many :allowlist_domains
-    has_many :allowlist_emails
+    has_many :allowlist_domains, dependent: :destroy
+    has_many :allowlist_emails, dependent: :destroy
     validates :name, presence: true, uniqueness: true
 end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_11_30_064213) do
-
   create_table "allowlist_domains", force: :cascade do |t|
     t.string "domain"
     t.string "usertype"
@@ -68,8 +67,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_30_064213) do
   end
 
   create_table "faqs", force: :cascade do |t|
-    t.string "question"
-    t.text "answer"
+    t.string "question", null: false
+    t.text "answer", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -91,7 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_30_064213) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status"
+    t.string "status", default: "pending"
     t.index ["meeting_id"], name: "index_user_meetings_on_meeting_id"
     t.index ["user_id"], name: "index_user_meetings_on_user_id"
   end

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -708,3 +708,36 @@ Feature: Allowlist Management
         And I delete company with id 1
         And I should see 0 new email in the database
         And I should see 3 domain in the database
+
+    Scenario: Company deletion cascades to allowlists and then to users
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new primary contact company email test@test.com for usertype company representative for company id 1
+        And I allow a new company domain test2.com for usertype company representative for company id 1
+        And that I sign up with the following
+            | firstname | james1 |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test@test.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I sign up with the following
+            | firstname | james2 |
+            | lastname | bond |
+            | password | password1! |
+            | password_confirmation | password1! |
+            | email | test2@test2.com |
+            | usertype | company representative |
+            | company_id | 1 |
+        And that I log in as admin
+        Then the user with firstname james1 and lastname bond should be found in the user DB
+        And the user with firstname james2 and lastname bond should be found in the user DB
+        And I should see allowlist emails and domains in company 1 when indexing
+        And I should see 1 new email in the database
+        And I should see 4 domain in the database
+        Given I delete company with id 1
+        And I should see 0 new email in the database
+        And I should see 3 domain in the database
+        And the user with firstname james1 and lastname bond should NOT be found in the user DB
+        And the user with firstname james2 and lastname bond should NOT be found in the user DB

--- a/server/features/allowlist.feature
+++ b/server/features/allowlist.feature
@@ -695,3 +695,16 @@ Feature: Allowlist Management
         And that I log in with email test@test.com and password password1!
         Then I should not see allowlist emails and domains in company 1 when indexing
         And that I log out
+
+    Scenario: Company deletion cascades to allowlists     
+        Given that I log in as admin
+        And there is a company with id 1
+        And I allow a new company email test@test1.com for usertype company representative for company id 1
+        And I allow a new company email test@test2.com for usertype company representative for company id 1
+        And I allow a new company domain test3.com for usertype company representative for company id 1
+        Then I should see allowlist emails and domains in company 1 when indexing
+        And I should see 2 new email in the database
+        And I should see 4 domain in the database
+        And I delete company with id 1
+        And I should see 0 new email in the database
+        And I should see 3 domain in the database

--- a/server/features/step_definitions/company.rb
+++ b/server/features/step_definitions/company.rb
@@ -43,3 +43,8 @@ Then("I should see {int} reps for company with id {int}") do |int, cid|
   expect(ret.status).to eq(200)
   expect(ret_body["users"].length).to eq(int)
 end
+
+Given("I delete company with id {int}") do |cid|
+  ret = page.driver.delete("/companies/" + cid.to_s)
+  expect(ret.status).to eq(200)
+end


### PR DESCRIPTION
When deleting a company, all of that company's associated users and allowlist entries are now deleted as well