### PR TITLE
Return users as part of events and add event_signups routes

### DIFF
--- a/server/app/controllers/event_signups_controller.rb
+++ b/server/app/controllers/event_signups_controller.rb
@@ -1,0 +1,22 @@
+class EventSignupsController < ApplicationController
+  # GET /event_signups
+  def index
+    render json: {
+             event_signups: EventSignup.all,
+           }, status: :ok
+  end
+
+  # GET /event_signups/1
+  def show
+    event_signup = EventSignup.find(params[:id])
+    if !event_signup
+      render json: {
+               errors: ["Event signup with id #{params[:id]}"],
+             }, status: :not_found
+      return
+    end
+    render json: {
+             event_signup: event_signup,
+           }, status: :ok
+  end
+end

--- a/server/app/models/event.rb
+++ b/server/app/models/event.rb
@@ -4,4 +4,10 @@ class Event < ApplicationRecord
   has_many :meetings
   has_many :availabilities
   validates :start_time, comparison: { less_than: :end_time }
+
+  def as_json(options = {})
+    ret = super(options)
+    ret["users"] = self.users.as_json
+    return ret
+  end
 end

--- a/server/app/models/event_signup.rb
+++ b/server/app/models/event_signup.rb
@@ -1,4 +1,11 @@
 class EventSignup < ApplicationRecord
   belongs_to :user
   belongs_to :event
+
+  def as_json(options = {})
+    ret = {}
+    ret["user"] = self.user.as_json
+    ret["event"] = self.event.as_json
+    return ret
+  end
 end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -70,4 +70,6 @@ Rails.application.routes.draw do
   post "events/:id/signup/:user_id", to: "events#signup"
   delete "events/:id/signout", to: "events#signout"
   delete "events/:id/signout/:user_id", to: "events#signout"
+
+  resources :event_signups, only: [:index, :show]
 end

--- a/server/features/event_signup.feature
+++ b/server/features/event_signup.feature
@@ -151,3 +151,42 @@ Feature: Event Signup
             | 2 |
         Then the following "volunteer" users should be signed up to event 2
             | 2 |
+    
+    Scenario: Get signed up users
+        # User 1, admin
+        Given that I log in as admin
+        # Event 1-2
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-31 18:20:00' |
+        Then creating an event with the following should return code 201
+            | title | Another event |
+            | description | Something |
+            | start_time | '2022-11-01 18:10:00' |
+            | end_time | '2022-11-03 18:20:00' |
+        And I allow a new domain tamu.edu for usertype volunteer
+        # User 2
+        And that I sign up and log in as a valid volunteer
+        And I sign up to event 1 and receive code 200
+        And I sign up to event 2 and receive code 200
+        # User 3
+        And that I sign up and log in as a valid student
+        And I sign up to event 1 and receive code 200
+        And I sign up to event 2 and receive code 200
+        # User 4
+        And that I sign up and log in as a valid student
+        And I sign up to event 1 and receive code 200
+        And I sign up to event 2 and receive code 200
+        # User 5
+        And that I sign up and log in as a valid volunteer
+        And I sign up to event 2 and receive code 200
+        # Cannot signup multiple times
+        And I sign up to event 2 and receive code 400
+        Then the following users should be fetched with event 1
+            | 2 | 3 | 4 |
+        Then the following users should be fetched with event 2
+            | 2 | 3 | 4 | 5 |
+        And there should be 7 event_signups
+        And event_signup with id 1 should involve event 1 and user 2

--- a/server/features/step_definitions/event_signup.rb
+++ b/server/features/step_definitions/event_signup.rb
@@ -64,3 +64,24 @@ Given("I sign out user {int} from event {int} and receive code {int}") do |user_
   ret = page.driver.delete("/events/#{id}/signout/#{user_id}")
   expect(ret.status).to eq(code)
 end
+
+Then("the following users should be fetched with event {int}") do |id, table|
+  ret = page.driver.get("/events/#{id}")
+  ret_body = JSON.parse ret.body
+  actual = []
+  ret_body["event"]["users"].each { |h| actual << h["id"].to_s }
+  expect(actual).to eq(table.raw[0].each { |id| id.to_i })
+end
+
+Then("there should be {int} event_signups") do |count|
+  ret = page.driver.get("/event_signups")
+  ret_body = JSON.parse ret.body
+  expect(ret_body["event_signups"].length).to eq(count)
+end
+
+Then("event_signup with id {int} should involve event {int} and user {int}") do |id, event_id, user_id|
+  ret = page.driver.get("/event_signups/#{id}")
+  ret_body = JSON.parse ret.body
+  expect(ret_body["event_signup"]["event"]["id"]).to eq(event_id)
+  expect(ret_body["event_signup"]["user"]["id"]).to eq(user_id)
+end


### PR DESCRIPTION
- Event now returns signed up users
- Added event_signups routes
  - GET `/event_signups/`
  - GET `/event_signups/`
- Event signups return user object and event object instead of `user_id` and `event_id`