### PR TITLE
Return ids instead of actual instances

### DIFF
--- a/server/app/models/event.rb
+++ b/server/app/models/event.rb
@@ -7,7 +7,10 @@ class Event < ApplicationRecord
 
   def as_json(options = {})
     ret = super(options)
-    ret["users"] = self.users.as_json
+    ret["user_ids"] = []
+    for user in self.users
+      ret["user_ids"] << user.id
+    end
     return ret
   end
 end

--- a/server/app/models/event_signup.rb
+++ b/server/app/models/event_signup.rb
@@ -1,11 +1,4 @@
 class EventSignup < ApplicationRecord
   belongs_to :user
   belongs_to :event
-
-  def as_json(options = {})
-    ret = {}
-    ret["user"] = self.user.as_json
-    ret["event"] = self.event.as_json
-    return ret
-  end
 end

--- a/server/features/step_definitions/event_signup.rb
+++ b/server/features/step_definitions/event_signup.rb
@@ -69,7 +69,7 @@ Then("the following users should be fetched with event {int}") do |id, table|
   ret = page.driver.get("/events/#{id}")
   ret_body = JSON.parse ret.body
   actual = []
-  ret_body["event"]["users"].each { |h| actual << h["id"].to_s }
+  ret_body["event"]["user_ids"].each { |h| actual << h.to_s }
   expect(actual).to eq(table.raw[0].each { |id| id.to_i })
 end
 
@@ -82,6 +82,6 @@ end
 Then("event_signup with id {int} should involve event {int} and user {int}") do |id, event_id, user_id|
   ret = page.driver.get("/event_signups/#{id}")
   ret_body = JSON.parse ret.body
-  expect(ret_body["event_signup"]["event"]["id"]).to eq(event_id)
-  expect(ret_body["event_signup"]["user"]["id"]).to eq(user_id)
+  expect(ret_body["event_signup"]["event_id"]).to eq(event_id)
+  expect(ret_body["event_signup"]["user_id"]).to eq(user_id)
 end


### PR DESCRIPTION
- Event APIs are returning associated user ids and event ids instead of the actual instances