### PR TITLE
Deletes meetings and invites when user signs out of an event

### DIFF
--- a/server/features/event_signup.feature
+++ b/server/features/event_signup.feature
@@ -190,3 +190,55 @@ Feature: Event Signup
             | 2 | 3 | 4 | 5 |
         And there should be 7 event_signups
         And event_signup with id 1 should involve event 1 and user 2
+    
+
+    Scenario: Signout deletes meetings and invites
+        # User 1, admin
+        Given that I log in as admin
+        # Event 1-2
+        Then creating an event with the following should return code 201
+            | title | Mock interview |
+            | description | Something |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-31 18:20:00' |
+        And I allow a new domain tamu.edu for usertype volunteer
+        # User 2
+        And that I sign up and log in as a valid volunteer
+        And I sign up to event 1 and receive code 200
+        # User 3
+        And that I sign up and log in as a valid student
+        And I sign up to event 1 and receive code 200
+        # User 4
+        And that I sign up and log in as a valid student
+        And I sign up to event 1 and receive code 200
+        # User 5
+        And that I sign up and log in as a valid volunteer
+        And I sign up to event 1 and receive code 200
+        # Cannot signup multiple times
+        And I sign up to event 1 and receive code 400
+        And that I log in as admin
+        # Create meeting 1 ~ 2
+        And that I create a meeting with the following
+            | title | A meeting |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+            | owner_id | 2 |
+            | event_id | 1 |
+        And that I create a meeting with the following
+            | title | Great meeting |
+            | start_time | '2022-10-18 18:10:00' |
+            | end_time | '2022-10-18 18:20:00' |
+            | owner_id | 3 |
+            | event_id | 1 |
+        And that I assign user 2 to meeting 2 with status "pending"
+        And that I assign user 4 to meeting 2 with status "pending"
+        And that I assign user 5 to meeting 2 with status "pending"
+        Then event 1 should have following associated meetings
+            | 1 | 2 |
+        Then meeting 2 should have as "pending" invitees the following users
+            | 2 | 4 | 5 |
+        And I sign out user 2 of event 1 and receive code 200
+        Then event 1 should have following associated meetings
+            | 2 |
+        Then meeting 2 should have as "pending" invitees the following users
+            | 4 | 5 |

--- a/server/features/step_definitions/event_signup.rb
+++ b/server/features/step_definitions/event_signup.rb
@@ -85,3 +85,8 @@ Then("event_signup with id {int} should involve event {int} and user {int}") do 
   expect(ret_body["event_signup"]["event"]["id"]).to eq(event_id)
   expect(ret_body["event_signup"]["user"]["id"]).to eq(user_id)
 end
+
+Then("I sign out user {int} of event {int} and receive code {int}") do |user_id, event_id, code|
+  ret = page.driver.delete("/events/#{event_id}/signout/#{user_id}")
+  expect(ret.status).to eq(code)
+end


### PR DESCRIPTION
- When user signs out of an event the following are deleted
  - User owned meetings associated with the event
  - User's invites to the meetings (not owned) associated with the event (only the invites/user-meetings)