### PR TITLE
changed minimum FAQ Question and Answer Field lengths to 1

### DIFF
--- a/server/app/models/faq.rb
+++ b/server/app/models/faq.rb
@@ -1,6 +1,6 @@
 class Faq < ApplicationRecord
 
-    validates :question, presence: true, length: { minimum: 10 }, allow_blank: false
-    validates :answer, presence: true, length: { minimum: 2 }, allow_blank: false
+    validates :question, presence: true, length: { minimum: 1 }, allow_blank: false
+    validates :answer, presence: true, length: { minimum: 1 }, allow_blank: false
 
 end


### PR DESCRIPTION
Just changed a couple of lines in the FAQ model validation to allow for minimum length of question and answer attributes be 1