### PR TITLE
Use registration times on fe

### DIFF
--- a/client/src/Shared/entityClasses/Event.ts
+++ b/client/src/Shared/entityClasses/Event.ts
@@ -9,6 +9,8 @@ export interface IEvent {
   description: string;
   start_time: string
   end_time: string;
+  registration_start_time: string;
+  registration_end_time: string;
 }
 
 export default class Event implements IEvent {
@@ -17,13 +19,17 @@ export default class Event implements IEvent {
   public readonly description: string;
   public readonly start_time: string;
   public readonly end_time: string;
+  public readonly registration_start_time: string;
+  public readonly registration_end_time: string;
 
-  public constructor({ id, title, description, start_time, end_time }: IEvent) {
+  public constructor({ id, title, description, start_time, end_time, registration_start_time, registration_end_time }: IEvent) {
     this.id = id;
     this.title = title;
     this.description = description;
     this.start_time = start_time;
     this.end_time = end_time;
+    this.registration_start_time = registration_start_time;
+    this.registration_end_time = registration_end_time;
   }
 
   public createTimeSlots(sessionLengthMins: number, breakLengthMins: number): any[] {
@@ -48,6 +54,24 @@ export default class Event implements IEvent {
     }
 
     return timeSlots;
+  }
+
+  public get isPreRegistration(): boolean {
+    const now: string = new Date().toISOString();
+    return now < this.registration_start_time;
+  }
+
+  public get isPostRegistration(): boolean {
+    const now: string = new Date().toISOString();
+    return now > this.registration_end_time;
+  }
+
+  public get registrationIsClosed(): boolean {
+    return this.isPreRegistration || this.isPostRegistration;
+  }
+
+  public get registrationIsOpen(): boolean {
+    return !this.registrationIsClosed;
   }
 
   public findMeetings(meetings: Meeting[]): Meeting[] {

--- a/client/src/Views/ProfilePage/StudentTimesheet/StudentTimesheetPR2.tsx
+++ b/client/src/Views/ProfilePage/StudentTimesheet/StudentTimesheetPR2.tsx
@@ -43,6 +43,9 @@ const mapStateToProps = (state: IRootState, ownProps: any) => {
   return {
     event,
     isAttendingEvent,
+    registrationIsOpen: event?.registrationIsOpen,
+    isPreRegistration: event?.isPreRegistration,
+    isPostRegistration: event?.isPostRegistration,
     users: state.userData.users,
     meetings: state.auth.user?.findInvitedMeetings(event?.findMeetings(state.meetingData.meetings) ?? []) ?? [],
 
@@ -130,6 +133,9 @@ class VolunteerTimesheetPR2 extends React.Component<Props, OwnState> {
     const {
       event,
       isAttendingEvent,
+      registrationIsOpen,
+      isPreRegistration,
+      isPostRegistration,
     } = this.props;
 
     if (this.props.isLoading) {
@@ -148,17 +154,28 @@ class VolunteerTimesheetPR2 extends React.Component<Props, OwnState> {
     return (
       <div className="Student-Timesheet">
         <h2>Student Timesheet</h2>
-        <button
-          onClick={() => isAttendingEvent
-            ? this.props.deleteEventSignup(event?.id ?? -1)
-            : this.props.createEventSignup(event?.id ?? -1)
-          }
-        >
-          {`${isAttendingEvent ? 'Unr' : 'R'}egister for ${event?.title}`}
-        </button>
         {
-          !isAttendingEvent &&
-          <div>Timesheet not viewable. Please register for this event!</div>
+          registrationIsOpen &&
+            <button
+              onClick={() => isAttendingEvent
+                ? this.props.deleteEventSignup(event?.id ?? -1)
+                : this.props.createEventSignup(event?.id ?? -1)}
+            >
+              {`${isAttendingEvent ? 'Unr' : 'R'}egister for ${event?.title}`}
+            </button>
+        }
+        {
+          isPreRegistration &&
+          <p>Registration is currently not yet open. No registration changes can be made at this time.</p>
+        }
+        {
+          isPostRegistration &&
+          <p>Registration is currently closed. No registration changes can be made at this time.</p>
+        }
+
+        {
+          !isAttendingEvent && isPostRegistration &&
+          <div>{`Timesheet not available. ${registrationIsOpen ? 'Please register for this event!' : 'You did not register for this event!'}`}</div>
         }
 
         {

--- a/client/src/Views/ProfilePage/VolunteerTimesheet/VolunteerTimesheetPR2.tsx
+++ b/client/src/Views/ProfilePage/VolunteerTimesheet/VolunteerTimesheetPR2.tsx
@@ -44,6 +44,9 @@ const mapStateToProps = (state: IRootState, ownProps: any) => {
 
   return {
     event,
+    registrationIsOpen: event?.registrationIsOpen,
+    isPreRegistration: event?.isPreRegistration,
+    isPostRegistration: event?.isPostRegistration,
     isAttendingEvent,
     users: state.userData.users,
     meetings: state.auth.user?.findOwnedMeetings(event?.findMeetings(state.meetingData.meetings) ?? []) ?? [],
@@ -139,6 +142,7 @@ class VolunteerTimesheetPR2 extends React.Component<Props, OwnState> {
             meeting={meeting}
             assignedStudent={assignedStudent}
             setReaction={this._setReaction}
+            registrationIsOpen={this.props.registrationIsOpen}
           />
         </React.Fragment>
       );
@@ -149,6 +153,9 @@ class VolunteerTimesheetPR2 extends React.Component<Props, OwnState> {
     const {
       event,
       isAttendingEvent,
+      registrationIsOpen,
+      isPreRegistration,
+      isPostRegistration,
     } = this.props;
 
     if (this.props.isLoading) {
@@ -173,17 +180,29 @@ class VolunteerTimesheetPR2 extends React.Component<Props, OwnState> {
     return (
       <div className="Volunteer-Timesheet">
         <h2>Volunteer Timesheet</h2>
-        <button
-          onClick={() => isAttendingEvent
-            ? this.props.deleteEventSignup(event?.id ?? -1)
-            : this.props.createEventSignup(event?.id ?? -1)
-          }
-        >
-          {`${isAttendingEvent ? 'Unr' : 'R'}egister for ${event?.title}`}
-        </button>
+
         {
-          !isAttendingEvent &&
-          <div>Timesheet not viewable. Please register for this event!</div>
+          registrationIsOpen &&
+            <button
+              onClick={() => isAttendingEvent
+                ? this.props.deleteEventSignup(event?.id ?? -1)
+                : this.props.createEventSignup(event?.id ?? -1)}
+            >
+              {`${isAttendingEvent ? 'Unr' : 'R'}egister for ${event?.title}`}
+            </button>
+        }
+        {
+          isPreRegistration &&
+          <p>Registration is currently not yet open. No registration changes or timeslot modifications can be made at this time.</p>
+        }
+        {
+          isPostRegistration &&
+          <p>Registration is currently closed. No registration changes or timeslot modifications can be made at this time.</p>
+        }
+
+        {
+          !isAttendingEvent && isPostRegistration &&
+          <div>{`Timesheet not available. ${registrationIsOpen ? 'Please register for this event!' : 'You did not register for this event!'}`}</div>
         }
 
         {
@@ -203,7 +222,10 @@ class VolunteerTimesheetPR2 extends React.Component<Props, OwnState> {
 
               </div>
             </div>
-            <button onClick={() => this._onSaveChanges()}>Save Changes</button>
+            {
+              registrationIsOpen && 
+              <button onClick={() => this._onSaveChanges()}>Save Changes</button>
+            }
           </>
         }
       </div>

--- a/client/src/Views/ProfilePage/VolunteerTimesheet/VolunteerTimesheetRow/VolunteerTimesheetRow.tsx
+++ b/client/src/Views/ProfilePage/VolunteerTimesheet/VolunteerTimesheetRow/VolunteerTimesheetRow.tsx
@@ -18,6 +18,7 @@ interface OwnProps {
   meeting: Meeting | null;
   setReaction: Function;
   assignedStudent?: User;
+  registrationIsOpen: boolean;
 }
 
 interface OwnState {
@@ -72,6 +73,7 @@ class VolunteerTimesheetRow extends React.Component<Props, OwnState> {
       end_time,
       hadMeeting,
       assignedStudent,
+      registrationIsOpen
     } = this.props;
     
     const startTimeShort = msToTimeString(Date.parse(start_time), 'CST');
@@ -81,10 +83,13 @@ class VolunteerTimesheetRow extends React.Component<Props, OwnState> {
       <div className="VolunteerTimesheetRow table__row">
         <div className="table__cell table__cell--time">
           <button
-            onClick={() => {
-              hadMeeting ? this._deleteMeeting() : this._createMeeting();
-              this.setState({ isChanged: !this.state.isChanged })
-            }}
+            onClick={registrationIsOpen
+              ? () => {
+                hadMeeting ? this._deleteMeeting() : this._createMeeting();
+                this.setState({ isChanged: !this.state.isChanged })
+              }
+              : () => {}
+              }
             className={`table__time-button ${
               hadMeeting
               ? (this.state.isChanged ? 'table__time-button--deleting' : 'table__time-button--available')

--- a/server/db/seeds.rb
+++ b/server/db/seeds.rb
@@ -24,11 +24,12 @@ AllowlistDomain.create(domain: "exchange.tamu.edu", usertype: "student")
 # User.create(email: "student_3@exchange.tamu.edu", firstname: "Student", lastname: "Three", password: "pw", email_confirmed: true, usertype: "student");
 # User.create(email: "student_4@tamu.edu", firstname: "Student", lastname: "Four", password: "pw", email_confirmed: true, usertype: "student");
 
+#TODO: Correct the registration times
 case Rails.env
 when "production"
-  Event.create(title: "Portfolio Review 1", description: "First portfolio review", start_time: "2022-10-22T10:00:00CDT", end_time: "2022-10-22T16:00:00CDT")
-  Event.create(title: "Mock Interview 1", description: "First mock interview", start_time: "2023-02-16T10:00:00CST", end_time: "2023-02-16T16:00:00CST")
-  Event.create(title: "Mock Interview 2", description: "Second mock interview", start_time: "2023-02-17T10:00:00CST", end_time: "2023-02-17T16:00:00CST")
-  Event.create(title: "Portfolio Review 2", description: "Second portfolio review", start_time: "2023-02-18T10:00:00CST", end_time: "2023-02-18T16:00:00CST")
-  Event.create(title: "Virtual Fair", description: "Virtual Visualization Industry Fair (VIF)", start_time: "2023-02-23T10:00:00CST", end_time: "2023-02-23T16:00:00CST")
+  Event.create(title: "Portfolio Review 1", description: "First portfolio review", start_time: "2022-10-22T10:00:00CDT", end_time: "2022-10-22T16:00:00CDT", registration_start_time: "2022-10-11T10:00:00CDT", registration_end_time: "2022-18-15T17:00:00CDT")
+  Event.create(title: "Mock Interview 1", description: "First mock interview", start_time: "2023-02-16T10:00:00CST", end_time: "2023-02-16T16:00:00CST", registration_start_time: "2023-02-02T10:00:00CST", registration_end_time: "2023-02-09T17:00:00CST")
+  Event.create(title: "Mock Interview 2", description: "Second mock interview", start_time: "2023-02-17T10:00:00CST", end_time: "2023-02-17T16:00:00CST", registration_start_time: "2020-01-01T10:00:00CST", registration_end_time: "2024-01-01T17:00:00CST")
+  Event.create(title: "Portfolio Review 2", description: "Second portfolio review", start_time: "2023-02-18T10:00:00CST", end_time: "2023-02-18T16:00:00CST", registration_start_time: "2020-01-01T10:00:00CST", registration_end_time: "2024-01-01T17:00:00CST")
+  Event.create(title: "Virtual Fair", description: "Virtual Visualization Industry Fair (VIF)", start_time: "2023-02-23T10:00:00CST", end_time: "2023-02-23T16:00:00CST", registration_start_time: "2020-01-01T10:00:00CST", registration_end_time: "2024-01-01T17:00:00CST")
 end


### PR DESCRIPTION
Main features

- The UI now changes depending on the event's registration timeframe, disallowing any changes from non-admins if the current time is outside of an event's registration timeframe.

Other changes

- Further modified the seed data with some dummy registration times (since they aren't yet known)